### PR TITLE
chore: pin fluentassertions and stop dependabot bumping it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,10 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # FluentAssertions 8.x relicensed to the Xceed commercial license. Stay on the last
+      # Apache-2.0 line (7.x); ignore all updates so it is never bumped past the pinned 7.2.0.
+      - dependency-name: "FluentAssertions"
 
   # Frontend npm dependencies for the Vue sample (build-time dev tooling such as vite/esbuild).
   # These are not shipped in any published package, but keeping them current closes advisory


### PR DESCRIPTION
Keeps FluentAssertions on its last Apache-2.0 release (pinned 7.2.0) by telling dependabot to ignore all updates for it. The 8.x line moved to a commercial license, which this repo intentionally avoids.