### PR TITLE
fix: make the bindings regen workflow run on linux

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -52,7 +52,9 @@ jobs:
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           sudo add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-21 main"
           sudo apt-get update
-          sudo apt-get install -y libclang-21-dev
+          # clang-21 provides the clang binary (for -print-resource-dir) and pulls in the builtin
+          # headers (libclang-common-21-dev → stddef.h); libclang-21-dev provides libclang itself.
+          sudo apt-get install -y libclang-21-dev clang-21
 
       - name: Install ClangSharp
         run: dotnet tool install --global ClangSharpPInvokeGenerator

--- a/build/clangsharp/header.txt
+++ b/build/clangsharp/header.txt
@@ -2,4 +2,3 @@
 // saucer is Copyright (c) 2023 Saucer and licensed under the MIT License.
 // These files are a derivative work of those headers; see THIRD-PARTY-NOTICES.md
 // at the repository root for the full license text. Ryn itself is MIT-licensed.
-

--- a/build/clangsharp/ryn-bindings.rsp
+++ b/build/clangsharp/ryn-bindings.rsp
@@ -62,8 +62,3 @@ generate-callconv-member-function
 c++
 --std
 c++17
-
---additional
--isystem
---additional
-/opt/homebrew/Cellar/llvm@21/21.1.8/lib/clang/21/include

--- a/build/regenerate-bindings.sh
+++ b/build/regenerate-bindings.sh
@@ -43,6 +43,42 @@ CLANGSHARP_LIB_DIR="$(dirname "$CLANGSHARP_LIB")"
 echo "   libclang: $LLVM_LIB_DIR"
 echo "   libClangSharp: $CLANGSHARP_LIB_DIR"
 
+echo "==> Locating clang builtin headers (resource dir)..."
+# clang needs its own builtin headers (stddef.h, etc.) on the include path or every saucer header fails
+# with "'stddef.h' file not found". The resource dir is version- and platform-specific, so resolve it at
+# runtime instead of hardcoding a path. Anchor to the clang that ships beside the DETECTED libclang — a
+# bare `clang` on PATH can be a different toolchain (e.g. Apple clang) whose headers mismatch this libclang.
+RESOURCE_INCLUDE=""
+for clang_bin in \
+    "$(dirname "$LLVM_LIB_DIR")/bin/clang" \
+    "/usr/lib/llvm-21/bin/clang" \
+    "$(command -v clang-21 2>/dev/null || true)"; do
+    if [[ -n "$clang_bin" && -x "$clang_bin" ]]; then
+        rdir="$("$clang_bin" -print-resource-dir 2>/dev/null || true)"
+        if [[ -n "$rdir" && -f "$rdir/include/stddef.h" ]]; then
+            RESOURCE_INCLUDE="$rdir/include"
+            break
+        fi
+    fi
+done
+# Fallback: glob the resource include next to the detected libclang / the well-known llvm-21 layout.
+if [[ -z "$RESOURCE_INCLUDE" ]]; then
+    for g in "$LLVM_LIB_DIR"/clang/*/include \
+             "$(dirname "$LLVM_LIB_DIR")"/lib/clang/*/include \
+             /usr/lib/llvm-21/lib/clang/*/include; do
+        if [[ -f "$g/stddef.h" ]]; then
+            RESOURCE_INCLUDE="$g"
+            break
+        fi
+    done
+fi
+if [[ -z "$RESOURCE_INCLUDE" ]]; then
+    echo "ERROR: could not locate clang builtin headers (stddef.h). On Linux install clang-21 (or" >&2
+    echo "       libclang-common-21-dev); on macOS install llvm@21 (brew install llvm@21)." >&2
+    exit 1
+fi
+echo "   resource include: $RESOURCE_INCLUDE"
+
 echo "==> Clearing existing generated bindings..."
 # Clear only the ClangSharp output subdirectory (matches --output in ryn-bindings.rsp). Clearing the
 # whole $OUTPUT_DIR would also delete Generated/.editorconfig, which marks these files generated and
@@ -53,14 +89,29 @@ mkdir -p "$OUTPUT_DIR/Saucer.cs"
 echo "==> Generating C# bindings from saucer headers..."
 cd "$CONFIG_DIR"
 
+# ClangSharp returns a NON-ZERO exit code whenever it emits warnings. The saucer headers use a
+# 'Visibility' attribute it does not model, so it always warns "Generated bindings may be incomplete" —
+# benign, the bindings we ship are generated with these same warnings. Don't let that abort the script
+# (set -e): capture the code, then gate real success on actual file generation + a clean build below,
+# which catches any genuine failure (missing/garbage bindings won't compile).
+set +e
 if [[ "$(uname)" == "Darwin" ]]; then
-    DYLD_LIBRARY_PATH="$LLVM_LIB_DIR:$CLANGSHARP_LIB_DIR" ClangSharpPInvokeGenerator @ryn-bindings.rsp
+    DYLD_LIBRARY_PATH="$LLVM_LIB_DIR:$CLANGSHARP_LIB_DIR" ClangSharpPInvokeGenerator @ryn-bindings.rsp --additional -isystem --additional "$RESOURCE_INCLUDE"
 else
-    LD_LIBRARY_PATH="$LLVM_LIB_DIR:$CLANGSHARP_LIB_DIR" ClangSharpPInvokeGenerator @ryn-bindings.rsp
+    LD_LIBRARY_PATH="$LLVM_LIB_DIR:$CLANGSHARP_LIB_DIR" ClangSharpPInvokeGenerator @ryn-bindings.rsp --additional -isystem --additional "$RESOURCE_INCLUDE"
+fi
+CLANGSHARP_RC=$?
+set -e
+if [[ "$CLANGSHARP_RC" -ne 0 ]]; then
+    echo "   note: ClangSharp exited $CLANGSHARP_RC (benign 'Unsupported attribute' warnings); verifying output below"
 fi
 
 FILE_COUNT=$(find "$OUTPUT_DIR" -name '*.cs' | wc -l | tr -d ' ')
 echo "==> Generated $FILE_COUNT C# files"
+if [[ "$FILE_COUNT" -eq 0 ]]; then
+    echo "ERROR: ClangSharp produced no .cs files — treating as a hard failure." >&2
+    exit 1
+fi
 
 echo "==> Verifying build..."
 cd "$REPO_ROOT"


### PR DESCRIPTION
The "Regenerate Bindings" workflow has failed **every run since it was created (2026-05-21)** — never gating, never green. Two stacked causes, both pre-existing:

1. `ryn-bindings.rsp` hardcoded a macOS clang resource path as `-isystem`, so on the Linux runner clang couldn't find its builtin headers → `fatal error: 'stddef.h' file not found`.
2. (Masked by #1) ClangSharp exits non-zero on the saucer headers' benign `Visibility`-attribute warnings, and `set -e` aborted the script before it verified the build.

## Fix (CI/tooling only — no product code, Generated/ untouched)
- Resolve clang's resource-include dir at runtime (anchored to the detected libclang, glob fallback, loud error if missing); remove the hardcoded path from the `.rsp`.
- Tolerate ClangSharp's warning exit; gate success on file generation + a clean `Ryn.Interop` build.
- Drop the trailing blank from `header.txt` so `--headerFile` reproduces the committed attribution header exactly (no regen churn).
- Install `clang-21` on the Linux runner (provides the binary + builtin headers).

## Verification
- **macOS (local):** `bash build/regenerate-bindings.sh` → exit 0, build clean, `git diff src/Ryn.Interop/Generated/` **empty** (regen reproduces committed files exactly).
- **Linux:** the "Regenerate Bindings" workflow is dispatched on this branch to confirm it goes green there before merge.