### PR TITLE
feat: multi-window support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ How Ryn compares on the axes that matter for a small, native, web-UI desktop app
 | IPC source generator | yes | n/a | no | no | n/a |
 | Scaffold/dev/bundle CLI | yes | yes | no | partial | dotnet |
 | Signed auto-updater | yes | yes | no | no | no |
-| Multi-window | no (planned) | yes | yes | yes | limited |
+| Multi-window | yes² | yes | yes | yes | limited |
 | Native app menus | no (planned) | yes | partial | yes | yes |
 | Mobile | no (desktop-only) | yes | no | no | yes |
 
 ¹ Photino is a thin wrapper; the deployed size depends on your own .NET app and runtime. The point of the row is the relative weight of the webview layer, not a head-to-head app size.
+
+² Multi-window: the API (open/track/close, per-window IPC) is complete on all platforms. On macOS a window opened after launch may currently paint only its background — a WebKit/saucer first-paint limitation; see [docs/multi-window.md](docs/multi-window.md).
 
 These numbers are for orientation, not a benchmark claim; they vary by platform, runtime mode (self-contained vs framework-dependent), and trimming. Ryn's ~5 MB figure is a NativeAOT hello-world on macOS arm64 (a full app pulling in every plugin is ~5.6 MB).
 

--- a/Ryn.slnx
+++ b/Ryn.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/samples/">
     <Project Path="samples/HelloWindow/HelloWindow.csproj" />
+    <Project Path="samples/MultiWindow/MultiWindow.csproj" />
     <Project Path="samples/Showcase/Showcase.csproj" />
     <Project Path="samples/ViteApp/ViteApp.csproj" />
     <Project Path="samples/TerminalApp/TerminalApp.csproj" />

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,20 +17,17 @@ Status legend:
 
 ## Near-term
 
-### Multi-window support
+### Multi-window support — **delivered**
 
-The public API today exposes a single window: `RynApplication` owns exactly one
-`RynWindow`, and closing it quits the app. Real desktop apps routinely need a
-settings window, a detached panel, or a multi-document interface, so a single
-window is a hard ceiling on what can be built on Ryn. The plan is a window manager
-that can open and track multiple `RynWindow` instances, each with its own webview
-and IPC routing, plus per-window identity in events. This touches `RynApplication`,
-`RynWindow`/`IRynWindow`, the `window.*` commands, and the IPC origin model; the
-already-bound saucer setters (fullscreen, always-on-top, min/max size, position,
-center) would be wrapped at the same time. Because retrofitting this later would
-be a breaking change, the 1.0 API surface should either land it or be shaped (for
-example `app.MainWindow`) so it can be added non-breakingly. Status: **Planned**.
-(tracks CMP-01, ARC-13)
+`RynApplication` is now a window manager: it owns one native event loop and tracks
+multiple `RynWindow` instances, each with its own webview and per-window IPC
+routing, exposed via `MainWindow`, `Windows`, `OpenWindow`/`OpenWindowAsync`, the
+`IRynWindowManager` service, and the `window.open`/`list`/`current`/`close`/… JS
+commands. Closing the last window (not the main one) quits the app. See
+[multi-window.md](multi-window.md). One open item remains: on macOS a window opened
+after launch may paint only its background (a WebKit/`saucer` first-paint limitation
+documented in that doc); the API surface is complete and unaffected. (tracks
+CMP-01, ARC-13)
 
 ### Application menu bar and global shortcuts
 

--- a/docs/multi-window.md
+++ b/docs/multi-window.md
@@ -1,0 +1,165 @@
+# Multi-window
+
+Ryn applications can open and manage more than one window. The application owns a
+single native event loop and application object; each window has its own webview,
+IPC token, scheme handler, and events, so windows are fully isolated from one
+another while sharing one process and one DI container.
+
+> **macOS limitation:** a window opened *after* the app has started may render only
+> its background, not its content. This is a WebKit issue, not a Ryn API gap — see
+> [Known limitation](#known-limitation-macos-secondary-window-rendering) below
+> before relying on multi-window on macOS.
+
+## Concepts
+
+- **Main window** — created when the app starts. `RynApplication.MainWindow` (and,
+  for backward compatibility, `RynApplication.Window`) always points at it. Closing
+  the main window no longer quits the app on its own; the app quits when the *last*
+  window closes.
+- **Secondary windows** — opened at runtime from C# or JavaScript. Each gets its own
+  integer `Id`, assigned in creation order (the main window is `1`).
+- **Per-window IPC** — the `window.*` commands act on the window that *originated*
+  the call. A button in a secondary window that invokes `window.close` closes *that*
+  window, not the main one.
+
+## C# API
+
+```csharp
+// Open a window and keep the handle.
+IRynWindow settings = app.OpenWindow(new RynWindowOptions
+{
+    Title  = "Settings",
+    Width  = 480,
+    Height = 360,
+    Html   = "<h1>Settings</h1>",
+});
+
+// Non-blocking variant.
+IRynWindow w = await app.OpenWindowAsync(new RynWindowOptions { Url = new Uri("http://localhost:5173") });
+
+IRynWindow main          = app.MainWindow;   // the first window
+IReadOnlyList<IRynWindow> all = app.Windows; // all open windows, main first
+```
+
+`OpenWindow` is safe to call from any thread: native window creation is marshalled
+onto the UI thread and the call blocks until the window exists. `OpenWindowAsync`
+returns once the window has been created without blocking the caller.
+
+To open windows from a service or command class without holding a `RynApplication`
+reference, inject `IRynWindowManager`:
+
+```csharp
+public sealed class MyCommands(IRynWindowManager windows)
+{
+    [RynCommand("app.openPanel")]
+    public int OpenPanel() => windows.OpenWindow(new RynWindowOptions { Title = "Panel" }).Id;
+}
+```
+
+### `RynWindowOptions`
+
+A per-window subset of `RynOptions` (the app-global fields — `ApplicationId`,
+`DeepLinkSchemes`, exception capture, default logging — are not per-window):
+
+| Property | Default | Notes |
+|---|---|---|
+| `Title` | `"Ryn Window"` | |
+| `Width` / `Height` | `800` / `600` | |
+| `Resizable` | `true` | |
+| `TitleBarStyle` | `Native` | |
+| `Transparent` | `false` | |
+| `Url` | `null` | loopback dev URL, or remote URL (IPC only wired for loopback/local) |
+| `Html` | `null` | inline HTML over the `ryn://` scheme |
+| `ContentDirectory` | `null` | a directory of static content |
+| `UseLocalServer` | `false` | serve `ContentDirectory` over loopback HTTP instead of `ryn://` |
+| `LocalServerPort` | `7421` | |
+| `IconPath` | `null` | |
+| `DevTools` | `false` | |
+| `PersistWindowState` | `false` | secondary windows persist under a per-`Id` key so they don't collide with the main window |
+| `AllowedOrigins` | `[]` | |
+| `CustomSchemes` | `[]` | |
+
+Provide exactly one of `Url` / `Html` / `ContentDirectory` for the window's content.
+
+## JavaScript API
+
+All commands are invoked through the bridge and routed to the originating window:
+
+```js
+// Open a window; returns its id (as a string).
+const id = await window.__ryn.invoke('window.open', {
+  title: 'JS child', width: 420, height: 320, html: '<h1>Hi</h1>',
+});
+
+await window.__ryn.invoke('window.current'); // this window's id (number)
+await window.__ryn.invoke('window.list');    // ids of all open windows (number[])
+
+// These act on the calling window:
+await window.__ryn.invoke('window.close');
+await window.__ryn.invoke('window.minimize');
+await window.__ryn.invoke('window.toggleMaximize');
+await window.__ryn.invoke('window.setTitle', { title: 'Renamed' });
+await window.__ryn.invoke('window.setSize', { width: 600, height: 400 });
+```
+
+`window.open` accepts the optional named arguments `title`, `width`, `height`,
+`resizable`, `devTools`, and one of `url` / `html` / `contentDirectory`. Omitted
+fields fall back to the window defaults.
+
+## Capabilities
+
+The `window` commands are governed by the capability system like any other. Grant
+them in `ryn.json` (a missing file allows everything, for development):
+
+```json
+{
+  "capabilities": {
+    "window": {
+      "allow": ["open", "list", "current", "close", "minimize", "toggleMaximize", "setTitle", "setSize"]
+    }
+  }
+}
+```
+
+`window.open` is the most powerful grant (it creates windows), so keep it explicit.
+See [capabilities.md](capabilities.md) for the full model.
+
+## Lifecycle
+
+- Closing a window removes it from `app.Windows` and fires its `Closed` event.
+- The app's event loop ends — and `RunAsync` returns — when the **last** window
+  closes, not when the main window closes.
+- `RequestShutdown()` closes all windows and ends the loop.
+
+## Known limitation: macOS secondary-window rendering
+
+On macOS, a window created **after** the application has started (i.e. any window
+other than the main one) may display only its page background — the content (text,
+controls, laid-out DOM) does not appear, even though the page loaded and its
+JavaScript ran.
+
+**Cause.** WebKit renders a `WKWebView`'s content only while its window is in the
+`NSWindowOcclusionStateVisible` state. The main window reaches that state during
+AppKit's launch display cycle; a window created after the run loop is already
+spinning does not reliably get that transition, so WebKit keeps its WebContent
+process throttled and only the background layer composites. This is a property of
+the underlying `saucer`/WebKit layer (saucer's own examples only ever create
+windows during launch), not of Ryn's window manager — the window, its IPC, its
+events, and `window.current`/`window.list` all work correctly; only the first paint
+is affected.
+
+**Status.** The multi-window **API is stable and complete**; the rendering gap is
+tracked against the native layer and does not affect the C#/JS surface. To reduce
+the visual impact, Ryn shows a secondary window before loading its content so it at
+least paints its themed background rather than a blank white view, and foregrounds
+the app on launch. Windows, Linux (WebKitGTK), and the main window on every platform
+are unaffected.
+
+If you hit this, prefer composing UI inside the main window (panels, routes,
+overlays) until the upstream fix lands.
+
+## Sample
+
+`samples/MultiWindow` opens a second window from JavaScript and a third from C#,
+tiles all three, and demonstrates per-window `window.current` / `window.list` and
+close-one-keeps-the-app-alive / close-last-quits.

--- a/samples/MultiWindow/Demo.cs
+++ b/samples/MultiWindow/Demo.cs
@@ -1,0 +1,55 @@
+namespace MultiWindow;
+
+/// <summary>Shared HTML for the demo windows, used by both the startup page and the C# IPC command.</summary>
+internal static class Demo
+{
+    /// <summary>A self-contained child page that asks the framework which window it is (window.current) and
+    /// lists every open window (window.list), proving IPC is wired per-window.</summary>
+    public static string ChildPage(string heading, string accent) => $$"""
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="utf-8" />
+          <title>{{heading}}</title>
+          <style>
+            * { margin: 0; padding: 0; box-sizing: border-box; }
+            body {
+              font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+              background: #0f0f17; color: #e6e6f0; height: 100vh;
+              display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 18px;
+            }
+            h1 { font-size: 1.5em; color: {{accent}}; }
+            .badge {
+              font-family: ui-monospace, monospace; font-size: 1.5em; font-weight: 700;
+              background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 12px; padding: 10px 22px;
+            }
+            .label { font-size: 12px; color: #8a8aa0; }
+            .list { font-family: ui-monospace, monospace; color: #a78bfa; }
+            button {
+              padding: 10px 18px; border-radius: 9px; border: none; cursor: pointer; font-weight: 600;
+              background: {{accent}}; color: #0f0f17; font-size: 14px;
+            }
+          </style>
+        </head>
+        <body>
+          <h1>{{heading}}</h1>
+          <div class="label">window.current() &rarr;</div>
+          <div class="badge" id="whoami">identifying...</div>
+          <div class="label">window.list() &rarr; <span class="list" id="list">...</span></div>
+          <button onclick="closeSelf()">Close this window</button>
+          <script>
+            async function whoami() {
+              const id = await window.__ryn.invoke('window.current', {});
+              document.getElementById('whoami').textContent = 'I am window #' + id;
+            }
+            async function refresh() {
+              const ids = await window.__ryn.invoke('window.list', {});
+              document.getElementById('list').textContent = JSON.stringify(ids);
+            }
+            function closeSelf() { window.__ryn.invoke('window.close', {}); }
+            whoami(); refresh();
+          </script>
+        </body>
+        </html>
+        """;
+}

--- a/samples/MultiWindow/DemoCommands.cs
+++ b/samples/MultiWindow/DemoCommands.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using Ryn.Core;
+using Ryn.Ipc;
+
+namespace MultiWindow;
+
+/// <summary>
+/// IPC commands the startup page calls so that opening the C#-side window and arranging the windows run on the
+/// IPC dispatch path. Both forward to <see cref="IRynWindowManager"/> — the same window-manager a background
+/// thread would use, but invoked while the event loop is actively servicing the request.
+/// </summary>
+#pragma warning disable CA1812 // Instantiated by generated DI code
+internal sealed class DemoCommands(IRynWindowManager windows)
+#pragma warning restore CA1812
+{
+    /// <summary>Opens the third window from C# and returns its id.</summary>
+    [RynCommand("demo.openFromCSharp")]
+    public int OpenFromCSharp() =>
+        windows.OpenWindow(new RynWindowOptions
+        {
+            Title = "Opened from C#",
+            Width = 420,
+            Height = 320,
+            Html = Demo.ChildPage("Opened from C#", "#f59e0b"),
+        }).Id;
+
+    /// <summary>Tiles the open windows so all three are visible at once instead of stacked.</summary>
+    [RynCommand("demo.tile")]
+    public void Tile()
+    {
+        var ordered = windows.Windows.OrderBy(w => w.Id).ToList();
+        var spots = new[] { (60, 80), (660, 80), (660, 460) };
+        for (var i = 0; i < ordered.Count && i < spots.Length; i++)
+            ordered[i].Move(spots[i].Item1, spots[i].Item2);
+    }
+}

--- a/samples/MultiWindow/MultiWindow.csproj
+++ b/samples/MultiWindow/MultiWindow.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishAot>true</PublishAot>
+    <NoWarn>CA2007;CA1515</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="ryn.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Ryn.Core\Ryn.Core.csproj" />
+    <ProjectReference Include="..\..\src\Ryn.Ipc\Ryn.Ipc.csproj" />
+    <ProjectReference Include="..\..\src\Ryn.Ipc.Generator\Ryn.Ipc.Generator.csproj"
+                      OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>

--- a/samples/MultiWindow/Program.cs
+++ b/samples/MultiWindow/Program.cs
@@ -1,0 +1,100 @@
+using MultiWindow;
+using Ryn.Core;
+using Ryn.Ipc;
+
+// The page used by the JS-opened child window, embedded into the main page below as a JS string literal via
+// JsonEncodedText.Encode, which escapes '<' and '>' to \uXXXX so the nested </script> can't prematurely close
+// the main page's own script element.
+var jsChildLiteral = System.Text.Json.JsonEncodedText.Encode(Demo.ChildPage("JS child", "#34d399")).ToString();
+
+// The main "hub" window: identifies itself, lists the open windows, and on load opens the other two windows
+// and tiles them. The work is driven over IPC (window.open + the demo.* commands) so it runs on the event
+// loop's dispatch path and stays reliable even when nothing else is happening on screen.
+var mainPage = $$"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8" />
+      <title>Ryn Multi-Window</title>
+      <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+          background: #0f0f17; color: #e6e6f0; height: 100vh;
+          display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 22px;
+        }
+        h1 { font-size: 2em; color: #7c3aed; }
+        .badge {
+          font-family: ui-monospace, monospace; font-size: 1.8em; font-weight: 700;
+          background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 14px; padding: 12px 26px;
+        }
+        .card {
+          background: #1a1a2e; border: 1px solid #2a2a4a; border-radius: 14px;
+          padding: 20px; width: 440px; display: flex; flex-direction: column; gap: 12px;
+        }
+        .row { display: flex; gap: 10px; }
+        .label { font-size: 12px; color: #8a8aa0; }
+        .list { font-family: ui-monospace, monospace; color: #a78bfa; font-size: 1.1em; }
+        button {
+          flex: 1; padding: 11px 16px; border-radius: 9px; border: none; cursor: pointer; font-weight: 600;
+          background: #7c3aed; color: #fff; font-size: 14px;
+        }
+        button:hover { background: #6d28d9; }
+        button.ghost { background: #252540; }
+      </style>
+    </head>
+    <body>
+      <h1>Ryn Multi-Window</h1>
+      <div class="label">window.current() &rarr;</div>
+      <div class="badge" id="whoami">identifying...</div>
+      <div class="card">
+        <div class="row">
+          <button onclick="openChild()">Open JS child</button>
+          <button class="ghost" onclick="refresh()">Refresh list</button>
+        </div>
+        <div class="label">Open windows (window.list): <span class="list" id="list">...</span></div>
+      </div>
+      <script>
+        const childHtml = "{{jsChildLiteral}}";
+        async function whoami() {
+          const id = await window.__ryn.invoke('window.current', {});
+          document.getElementById('whoami').textContent = 'I am window #' + id + ' (main)';
+        }
+        async function refresh() {
+          const ids = await window.__ryn.invoke('window.list', {});
+          document.getElementById('list').textContent = JSON.stringify(ids);
+        }
+        async function openChild() {
+          await window.__ryn.invoke('window.open', { title: 'JS child', width: 420, height: 320, html: childHtml });
+          refresh();
+        }
+        async function setup() {
+          await openChild();                                  // window #2, opened from JavaScript
+          await window.__ryn.invoke('demo.openFromCSharp', {}); // window #3, opened from C#
+          await window.__ryn.invoke('demo.tile', {});           // arrange all three
+          refresh();
+        }
+        whoami(); refresh();
+        // Open the other windows shortly after load so the multi-window layout appears on its own.
+        setTimeout(setup, 500);
+      </script>
+    </body>
+    </html>
+    """;
+
+var app = RynApplication.CreateBuilder()
+    .ConfigureOptions(opts =>
+    {
+        opts.Title = "Ryn Multi-Window (Main)";
+        opts.Width = 560;
+        opts.Height = 620;
+        opts.Html = mainPage;
+    })
+    .ConfigureServices(services =>
+    {
+        services.AddRynCommands();
+        services.AddDemoCommands();
+    })
+    .Build();
+
+app.Run();

--- a/samples/MultiWindow/ryn.json
+++ b/samples/MultiWindow/ryn.json
@@ -1,0 +1,10 @@
+{
+  "capabilities": {
+    "window": {
+      "allow": ["open", "list", "current", "close", "minimize", "toggleMaximize", "setTitle", "setSize"]
+    },
+    "demo": {
+      "allow": ["openFromCSharp", "tile"]
+    }
+  }
+}

--- a/src/Ryn.Core/CurrentWindowAccessor.cs
+++ b/src/Ryn.Core/CurrentWindowAccessor.cs
@@ -1,0 +1,25 @@
+using Ryn.Core.Internal;
+
+namespace Ryn.Core;
+
+/// <summary>
+/// Resolves the window an IPC command originated from, so a command (e.g. the built-in <c>window.*</c> set)
+/// acts on the window whose page invoked it rather than always on the main window. Injected into command
+/// classes via DI. Returns the ambient originating window when called on an IPC dispatch path, falling back to
+/// the main window for any other caller (or before the ambient is set).
+/// </summary>
+public sealed class CurrentWindowAccessor
+{
+    private readonly NativeApplicationAccessor _appAccessor;
+
+    internal CurrentWindowAccessor(NativeApplicationAccessor appAccessor) => _appAccessor = appAccessor;
+
+    /// <summary>
+    /// The window the in-flight IPC command came from, or the main window when there is no originating window
+    /// (a non-IPC caller, or the ambient has not been set). Throws if the application is not running.
+    /// </summary>
+    public IRynWindow Current =>
+        CurrentWindow.Value
+        ?? _appAccessor.Host?.MainWindow
+        ?? throw new InvalidOperationException("No window is available; the application is not running.");
+}

--- a/src/Ryn.Core/IRynWindow.cs
+++ b/src/Ryn.Core/IRynWindow.cs
@@ -3,6 +3,8 @@ namespace Ryn.Core;
 /// <summary>Represents the native application window.</summary>
 public interface IRynWindow
 {
+    /// <summary>A stable identifier for this window, unique within the application. The main window is 1.</summary>
+    public int Id { get; }
     /// <summary>The window title text.</summary>
     public string Title { get; set; }
     /// <summary>The window width in pixels.</summary>

--- a/src/Ryn.Core/IRynWindow.cs
+++ b/src/Ryn.Core/IRynWindow.cs
@@ -49,6 +49,8 @@ public interface IRynWindow
     public void Minimize();
     /// <summary>Toggles between maximized and restored window states.</summary>
     public void ToggleMaximize();
+    /// <summary>Moves the window's top-left corner to the given screen coordinates (in points).</summary>
+    public void Move(int x, int y);
     /// <summary>Initiates a window drag operation (for frameless windows).</summary>
     public void StartDrag();
     /// <summary>Initiates a window resize operation from the specified edge.</summary>

--- a/src/Ryn.Core/IRynWindowManager.cs
+++ b/src/Ryn.Core/IRynWindowManager.cs
@@ -1,0 +1,23 @@
+namespace Ryn.Core;
+
+/// <summary>
+/// Opens and enumerates application windows at runtime. Injected into command classes (and resolvable by any
+/// service) so code can open secondary windows without holding a <see cref="RynApplication"/> reference.
+/// </summary>
+public interface IRynWindowManager
+{
+    /// <summary>
+    /// Opens a new window and returns it. Safe to call from any thread; native window creation is marshalled
+    /// onto the UI thread and the call blocks until the window exists. Throws if the application is not running.
+    /// </summary>
+    public IRynWindow OpenWindow(RynWindowOptions options);
+
+    /// <summary>
+    /// Opens a new window without blocking, completing once it has been created on the UI thread. Throws if the
+    /// application is not running.
+    /// </summary>
+    public Task<IRynWindow> OpenWindowAsync(RynWindowOptions options);
+
+    /// <summary>All currently-open windows, main first. Empty before the application is running.</summary>
+    public IReadOnlyList<IRynWindow> Windows { get; }
+}

--- a/src/Ryn.Core/Internal/CurrentWindow.cs
+++ b/src/Ryn.Core/Internal/CurrentWindow.cs
@@ -1,0 +1,19 @@
+namespace Ryn.Core.Internal;
+
+/// <summary>
+/// Ambient "which window is this IPC call from" slot, backed by <see cref="AsyncLocal{T}"/>. Set in
+/// <see cref="RynWebView.ExecuteCommandAsync"/> before the command dispatch hops to a worker thread, so it
+/// flows into the dispatched <c>[RynCommand]</c> via the captured <see cref="System.Threading.ExecutionContext"/>.
+/// Each command call has its own logical async slot, so concurrent calls from different windows never collide.
+/// Read through <see cref="CurrentWindowAccessor"/>, which falls back to the main window when no ambient is set.
+/// </summary>
+internal static class CurrentWindow
+{
+    private static readonly AsyncLocal<IRynWindow?> Slot = new();
+
+    internal static IRynWindow? Value
+    {
+        get => Slot.Value;
+        set => Slot.Value = value;
+    }
+}

--- a/src/Ryn.Core/Internal/DeferredRynWindow.cs
+++ b/src/Ryn.Core/Internal/DeferredRynWindow.cs
@@ -42,6 +42,7 @@ internal sealed class DeferredRynWindow(RynWindowAccessor accessor) : IRynWindow
         ?? throw new InvalidOperationException(
             "The window is not available yet. IRynWindow can be injected anywhere, but its members are only usable after RunAsync has started.");
 
+    public int Id => Live.Id;
     public string Title { get => Live.Title; set => Live.Title = value; }
     public int Width { get => Live.Width; set => Live.Width = value; }
     public int Height { get => Live.Height; set => Live.Height = value; }

--- a/src/Ryn.Core/Internal/DeferredRynWindow.cs
+++ b/src/Ryn.Core/Internal/DeferredRynWindow.cs
@@ -58,6 +58,7 @@ internal sealed class DeferredRynWindow(RynWindowAccessor accessor) : IRynWindow
     public void Close() => Live.Close();
     public void Minimize() => Live.Minimize();
     public void ToggleMaximize() => Live.ToggleMaximize();
+    public void Move(int x, int y) => Live.Move(x, y);
     public void StartDrag() => Live.StartDrag();
     public void StartResize(WindowEdge edge) => Live.StartResize(edge);
 

--- a/src/Ryn.Core/Internal/MacOsAppActivation.cs
+++ b/src/Ryn.Core/Internal/MacOsAppActivation.cs
@@ -1,0 +1,38 @@
+using System.Runtime.InteropServices;
+
+namespace Ryn.Core.Internal;
+
+/// <summary>
+/// Brings the application to the foreground on macOS via <c>[NSApp activateIgnoringOtherApps:YES]</c>. saucer
+/// presents a window but does not make the process the active application, and a terminal-launched (non-bundled)
+/// binary does not activate on its own, so without this the window is visible while its app stays inactive (no
+/// focus, behind other apps). macOS only; must run on the UI thread (AppKit is not thread-safe).
+/// </summary>
+[System.Runtime.Versioning.SupportedOSPlatform("macos")]
+internal static partial class MacOsAppActivation
+{
+    internal static void Activate()
+    {
+        var appClass = objc_getClass("NSApplication");
+        if (appClass == 0)
+            return;
+        var sharedApp = objc_msgSend(appClass, sel_registerName("sharedApplication"));
+        if (sharedApp == 0)
+            return;
+        objc_msgSend_bool(sharedApp, sel_registerName("activateIgnoringOtherApps:"), 1);
+    }
+
+    private const string Libobjc = "/usr/lib/libobjc.A.dylib";
+
+    [LibraryImport(Libobjc)]
+    private static partial nint objc_getClass([MarshalAs(UnmanagedType.LPStr)] string name);
+
+    [LibraryImport(Libobjc)]
+    private static partial nint sel_registerName([MarshalAs(UnmanagedType.LPStr)] string name);
+
+    [LibraryImport(Libobjc)]
+    private static partial nint objc_msgSend(nint receiver, nint selector);
+
+    [LibraryImport(Libobjc, EntryPoint = "objc_msgSend")]
+    private static partial nint objc_msgSend_bool(nint receiver, nint selector, byte arg);
+}

--- a/src/Ryn.Core/Internal/MacOsAppNap.cs
+++ b/src/Ryn.Core/Internal/MacOsAppNap.cs
@@ -1,0 +1,75 @@
+using System.Runtime.InteropServices;
+
+namespace Ryn.Core.Internal;
+
+/// <summary>
+/// Disables macOS App Nap for the application's lifetime. App Nap throttles a process that is not the active,
+/// foreground app — slowing or suspending its run loop, timers, and the main GCD queue. For a GUI app that
+/// must keep rendering and processing posted UI work (e.g. opening a window from a background thread) while it
+/// is in the background, that throttling makes that work stall until the app is brought to the foreground.
+/// Starting a long-lived <c>NSProcessInfo</c> "user initiated" activity opts the process out of App Nap while
+/// still allowing the system to sleep normally. macOS only; a no-op (and never called) elsewhere.
+/// </summary>
+[System.Runtime.Versioning.SupportedOSPlatform("macos")]
+internal static partial class MacOsAppNap
+{
+    // NSActivityUserInitiatedAllowingIdleSystemSleep: prevents App Nap / automatic termination but does NOT
+    // keep the display or system awake (0x00FFFFFF == NSActivityUserInitiated without the idle-sleep bit).
+    private const ulong NSActivityUserInitiatedAllowingIdleSystemSleep = 0x00FFFFFF;
+
+    // Retained activity token; held for the process lifetime so the activity stays in effect.
+    private static nint _activity;
+
+    internal static void Disable()
+    {
+        if (_activity != 0)
+            return;
+
+        var processInfoClass = objc_getClass("NSProcessInfo");
+        var stringClass = objc_getClass("NSString");
+        if (processInfoClass == 0 || stringClass == 0)
+            return;
+
+        var processInfo = objc_msgSend(processInfoClass, sel_registerName("processInfo"));
+        if (processInfo == 0)
+            return;
+
+        var reasonPtr = Marshal.StringToHGlobalAnsi("Ryn UI event loop");
+        nint reason;
+        try
+        {
+            reason = objc_msgSend_ptr(stringClass, sel_registerName("stringWithUTF8String:"), reasonPtr);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(reasonPtr);
+        }
+        if (reason == 0)
+            return;
+
+        var activity = objc_msgSend_activity(
+            processInfo,
+            sel_registerName("beginActivityWithOptions:reason:"),
+            NSActivityUserInitiatedAllowingIdleSystemSleep,
+            reason);
+        if (activity != 0)
+            _activity = objc_msgSend(activity, sel_registerName("retain"));
+    }
+
+    private const string Libobjc = "/usr/lib/libobjc.A.dylib";
+
+    [LibraryImport(Libobjc)]
+    private static partial nint objc_getClass([MarshalAs(UnmanagedType.LPStr)] string name);
+
+    [LibraryImport(Libobjc)]
+    private static partial nint sel_registerName([MarshalAs(UnmanagedType.LPStr)] string name);
+
+    [LibraryImport(Libobjc)]
+    private static partial nint objc_msgSend(nint receiver, nint selector);
+
+    [LibraryImport(Libobjc, EntryPoint = "objc_msgSend")]
+    private static partial nint objc_msgSend_ptr(nint receiver, nint selector, nint arg);
+
+    [LibraryImport(Libobjc, EntryPoint = "objc_msgSend")]
+    private static partial nint objc_msgSend_activity(nint receiver, nint selector, ulong options, nint reason);
+}

--- a/src/Ryn.Core/Internal/MainThreadDispatcher.cs
+++ b/src/Ryn.Core/Internal/MainThreadDispatcher.cs
@@ -1,65 +1,28 @@
 namespace Ryn.Core.Internal;
 
 /// <summary>
-/// Default <see cref="IMainThreadDispatcher"/>. Routes work to the live <see cref="RynWindow"/>'s main-thread
-/// post (<see cref="RynWindow.PostToUi"/> / <see cref="RynWindow.InvokeOnUiAsync"/>), using
-/// <see cref="RynWindowAccessor"/> so a caller that fires <b>before the window object exists</b> (e.g. a plugin
-/// backend during its <c>InitializeAsync</c>, which runs ahead of window creation) is still served.
+/// Default <see cref="IMainThreadDispatcher"/>. Marshals work onto the application's UI thread through the
+/// live <see cref="NativeAppHost"/> (published on <see cref="NativeApplicationAccessor"/> before plugins
+/// initialize), so a caller that fires <b>before the native loop is up</b> — e.g. a plugin backend during its
+/// <c>InitializeAsync</c> — is still served: the host buffers the work and drains it, in submission order, on
+/// the UI thread once the loop starts.
 /// </summary>
 /// <remarks>
-/// <para>
-/// The buffering is two-staged on purpose. Until the window <em>object</em> is published, work is queued in the
-/// accessor via <see cref="RynWindowAccessor.OnReady"/>. When the window is published (on the main thread) the
-/// queued closure runs and forwards to <see cref="RynWindow.PostToUi"/>; at that instant the <em>native</em>
-/// application usually does not exist yet, so the window buffers it a second time and drains it — in order, on
-/// the UI thread — once its native loop is up. The net effect: a pre-loop <see cref="Post"/> always lands on the
-/// UI thread once the loop starts, and a <see cref="Post"/> from the UI thread itself runs inline.
-/// </para>
-/// <para>
 /// Registered as a DI singleton by <see cref="RynApplicationBuilder.Build"/> so any service or plugin backend
-/// can resolve <see cref="IMainThreadDispatcher"/> and fence its native UI calls onto the main thread.
-/// </para>
+/// can resolve <see cref="IMainThreadDispatcher"/> and fence its native UI calls onto the main thread. A no-op
+/// when no host exists yet (the app was never run) — there is no event loop to post to.
 /// </remarks>
-internal sealed class MainThreadDispatcher(RynWindowAccessor accessor) : IMainThreadDispatcher
+internal sealed class MainThreadDispatcher(NativeApplicationAccessor accessor) : IMainThreadDispatcher
 {
     public void Post(Action action)
     {
         ArgumentNullException.ThrowIfNull(action);
-
-        // Window object already live → forward straight to its UI post (which itself runs inline when we are on
-        // the UI thread, or buffers/posts otherwise). Otherwise queue until the window is published; the queued
-        // closure then forwards to PostToUi, which handles the native-not-ready-yet case. The OnReady token is
-        // only needed to cancel a queued attach (subscribe/unsubscribe); fire-and-forget work never cancels.
-        _ = accessor.OnReady(window => window.PostToUi(action));
+        accessor.Host?.PostToUi(action);
     }
 
     public Task InvokeAsync(Action action)
     {
         ArgumentNullException.ThrowIfNull(action);
-
-        // Fast path: window already live → return its real completion task so callers genuinely await the work.
-        if (accessor.Window is { } live)
-            return live.InvokeOnUiAsync(action);
-
-        // Window not up yet: bridge OnReady (which fires on the main thread when the window publishes) to a
-        // TaskCompletionSource so the returned task still completes when the deferred work actually runs.
-        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        _ = accessor.OnReady(window =>
-        {
-            // Chain the window's UI-post task to our TCS so faults/cancellation propagate to the awaiter.
-            _ = window.InvokeOnUiAsync(action).ContinueWith(
-                static (t, state) =>
-                {
-                    var source = (TaskCompletionSource)state!;
-                    if (t.IsFaulted) source.TrySetException(t.Exception!.InnerExceptions);
-                    else if (t.IsCanceled) source.TrySetCanceled();
-                    else source.TrySetResult();
-                },
-                tcs,
-                CancellationToken.None,
-                TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
-        });
-        return tcs.Task;
+        return accessor.Host?.InvokeOnUiAsync(action) ?? Task.CompletedTask;
     }
 }

--- a/src/Ryn.Core/Internal/NativeAppHost.cs
+++ b/src/Ryn.Core/Internal/NativeAppHost.cs
@@ -1,0 +1,406 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Ryn.Interop;
+
+namespace Ryn.Core.Internal;
+
+/// <summary>
+/// Owns the one-per-process native saucer application and its blocking event loop, the UI-thread marshalling
+/// primitives, the global scheme registry, and the registry of live windows. Separated out of
+/// <see cref="RynWindow"/> so a single application/loop can host N windows: everything genuinely per-window
+/// (the native window/webview, IPC token, scheme handlers, events) stays on <see cref="RynWindow"/>, while
+/// everything that is one-per-process (the app handle, the run loop, the post/marshal helpers, the pre-ready
+/// queue) lives here. saucer natively supports N windows on one application, so the split is a separation of
+/// concerns rather than a rearchitecture.
+/// </summary>
+internal sealed unsafe class NativeAppHost : IDisposable
+{
+    // App-global options. For now this also carries the main window's per-window settings; the app is created
+    // from its ApplicationId and the main window is built from the whole instance.
+    private readonly RynOptions _mainWindowOptions;
+
+    private saucer_application* _app;
+    private void* _selfHandle;
+
+    // GCHandles posted to saucer's UI thread via RunOnUi. RunPostedAppAction normally claims-and-frees each
+    // one; tracking them here lets DisposeNative reclaim any the run loop dropped at shutdown (INT-10).
+    private readonly ConcurrentDictionary<nint, byte> _postedHandles = new();
+
+    // Main-thread work submitted (via IMainThreadDispatcher) before the native application exists. saucer's
+    // post requires a live _app, so RunOnUi drops actions while _app == null. Buffer them here and drain them
+    // — in submission order, on the UI thread — once the loop comes up (Cluster C / INT-02). Guarded by
+    // _preReadyGate; nulled after the drain so later posts go straight to RunOnUi.
+    private readonly object _preReadyGate = new();
+    private List<Action>? _preReadyQueue = [];
+    private volatile bool _appReady;
+
+    private volatile bool _disposed;
+
+    // Disposed after the saucer run loop exits so a late token cancellation can't quit a freed _app (PAP-14).
+    private CancellationTokenRegistration _quitRegistration;
+
+    // Live windows, keyed by id. The main window is created in OnReady; the loop quits when the registry
+    // empties. Guarded by _windowsGate because windows can be enumerated from teardown paths while the UI
+    // thread mutates the registry.
+    private readonly object _windowsGate = new();
+    private readonly Dictionary<int, RynWindow> _windows = [];
+    private int _nextWindowId;
+    private RynWindow? _mainWindow;
+
+    // Schemes already registered with the engine. saucer_webview_register_scheme is process-global and must
+    // run once, before the first webview is created; a double-register is a silent no-op but we guard anyway.
+    private readonly HashSet<string> _registeredSchemes = new(StringComparer.OrdinalIgnoreCase);
+
+    internal NativeAppHost(RynOptions mainWindowOptions) => _mainWindowOptions = mainWindowOptions;
+
+    /// <summary>The native application handle. Null until <see cref="Run"/> has created it.</summary>
+    internal saucer_application* App => _app;
+
+    /// <summary>True while the native application exists and the host has not begun teardown.</summary>
+    internal bool IsRunning => _app != null && !_disposed;
+
+    /// <summary>The first (main) window, once created in OnReady. Null before then.</summary>
+    internal RynWindow? MainWindow
+    {
+        get { lock (_windowsGate) return _mainWindow; }
+    }
+
+    /// <summary>A point-in-time snapshot of the live windows.</summary>
+    internal IReadOnlyList<RynWindow> Windows
+    {
+        get { lock (_windowsGate) return [.. _windows.Values]; }
+    }
+
+    /// <summary>Fires (on the UI thread, inside OnReady) with the native app handle once it exists.</summary>
+    internal Action<nint>? NativeReady { get; set; }
+
+    /// <summary>Fires (on the UI thread, inside OnReady) once the main window is fully initialized and live.</summary>
+    internal Action<RynWindow>? MainWindowCreated { get; set; }
+
+    /// <summary>The IPC command handler applied to each window's webview. Assigned before <see cref="Run"/>.</summary>
+    internal CommandDispatchHandler? CommandHandler { get; set; }
+
+    internal void Run(CancellationToken cancellationToken)
+    {
+        NativeLibraryResolver.Register();
+        Span<byte> idBuf = stackalloc byte[256];
+        var appIdStr = Utf8String.Create(_mainWindowOptions.ApplicationId, idBuf);
+        var appOpts = Saucer.saucer_application_options_new(appIdStr.Pointer);
+        appIdStr.Dispose();
+        int error = 0;
+        _app = Saucer.saucer_application_new(appOpts, &error);
+        Saucer.saucer_application_options_free(appOpts);
+        if (_app == null) throw new InvalidOperationException($"Failed to create saucer application (error code: {error})");
+        if (cancellationToken.CanBeCanceled)
+            _quitRegistration = cancellationToken.Register(() => { if (_app != null) Saucer.saucer_application_quit(_app); });
+        _selfHandle = NativeCallbackHelper.Alloc(this);
+        var exitCode = Saucer.saucer_application_run(_app,
+            (delegate* unmanaged[Cdecl]<saucer_application*, void*, void>)&OnReady,
+            (delegate* unmanaged[Cdecl]<saucer_application*, void*, void>)&OnFinish,
+            _selfHandle);
+        _ = exitCode;
+        // Dispose the cancellation registration before freeing _app: the registration is only meaningful while
+        // the loop runs, and disposing it here closes the post-shutdown closure pin and the TOCTOU window where
+        // a late cancellation could call saucer_application_quit on the freed _app (PAP-14).
+        _quitRegistration.Dispose();
+        _quitRegistration = default;
+        DisposeNative();
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnReady(saucer_application* app, void* userdata)
+    {
+        var self = NativeCallbackHelper.Resolve<NativeAppHost>(userdata);
+        NativeGuard.Invoke("NativeAppHost.OnReady", () =>
+        {
+            try
+            {
+                self.InitializeReady();
+            }
+            catch
+            {
+                // Startup failed (window/webview creation, local-server bind, state-dir creation, …). Quit the
+                // saucer loop so Run() can return and dispose cleanly, complete any open per-window close TCS so
+                // a WaitForCloseAsync awaiter is released, then rethrow into NativeGuard, which routes the
+                // exception to RynApplication's UnhandledException surface (ARC-01/INT-01/PAP-09).
+                if (self._app != null) Saucer.saucer_application_quit(self._app);
+                self.CompleteAllCloseSignals();
+                throw;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Brings the application up on the UI thread: publishes the native handle, creates and initializes the
+    /// main window, announces it, then drains any pre-ready main-thread work. Runs inside saucer's OnReady.
+    /// </summary>
+    private void InitializeReady()
+    {
+        NativeReady?.Invoke((nint)_app);
+
+        var main = CreateWindowCore(_mainWindowOptions);
+        if (CommandHandler is not null) main.SetCommandHandler(CommandHandler);
+        main.InitializeNative();
+
+        // Publish the fully-initialized window only after InitializeNative, so anything the announcement wakes
+        // up (a deferred IRynWebView flush, a queued IMainThreadDispatcher action) finds a live webview.
+        MainWindowCreated?.Invoke(main);
+
+        // We're on the UI thread and the app exists. Drain any main-thread work a plugin backend buffered via
+        // IMainThreadDispatcher before the loop was up (Cluster C / INT-02), in submission order.
+        FlushPreReadyQueue();
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnFinish(saucer_application* app, void* userdata)
+    {
+        var self = NativeCallbackHelper.Resolve<NativeAppHost>(userdata);
+        // The loop has ended; defensively complete any per-window close TCS still open so awaiters unblock.
+        NativeGuard.Invoke("NativeAppHost.OnFinish", () => self.CompleteAllCloseSignals());
+    }
+
+    /// <summary>Constructs and registers a window (managed only; native creation is the caller's next step).</summary>
+    private RynWindow CreateWindowCore(RynOptions options)
+    {
+        lock (_windowsGate)
+        {
+            var id = ++_nextWindowId;
+            var window = new RynWindow(this, id, options);
+            _windows[id] = window;
+            _mainWindow ??= window;
+            return window;
+        }
+    }
+
+    /// <summary>
+    /// Removes a closed window from the registry and quits the loop only when the last window has gone (the
+    /// key multi-window difference from the old hardcoded quit-on-any-close). Runs on the UI thread, called
+    /// from <see cref="RynWindow"/>'s native CLOSED handler.
+    /// </summary>
+    internal void OnWindowClosedInternal(RynWindow window)
+    {
+        bool empty;
+        lock (_windowsGate)
+        {
+            _windows.Remove(window.Id);
+            empty = _windows.Count == 0;
+        }
+        if (empty && _app != null)
+            Saucer.saucer_application_quit(_app);
+    }
+
+    private void CompleteAllCloseSignals()
+    {
+        foreach (var window in Windows)
+            window.CompleteCloseSignal();
+    }
+
+    /// <summary>
+    /// Requests an orderly shutdown from any thread: closes every live window on the UI thread so each runs its
+    /// native CLOSE/CLOSED path (window-state save), and the last close quits the loop. Falls back to quitting
+    /// the application directly if there is no window yet, so a shutdown request is never silently dropped.
+    /// </summary>
+    internal void RequestShutdown() => PostToUi(() =>
+    {
+        var windows = Windows;
+        if (windows.Count == 0)
+        {
+            if (_app != null) Saucer.saucer_application_quit(_app);
+            return;
+        }
+        foreach (var window in windows)
+            window.CloseNativeWindow();
+    });
+
+    /// <summary>Quits the saucer loop. Must be called on the UI thread.</summary>
+    internal void Quit()
+    {
+        if (_app != null) Saucer.saucer_application_quit(_app);
+    }
+
+    /// <summary>
+    /// Registers a custom URL scheme with the engine, exactly once across the process. saucer's
+    /// register_scheme is global and must run before the first webview is created; the <see cref="HashSet{T}"/>
+    /// guard makes a repeat call (e.g. the reserved "ryn" scheme, or a scheme shared across windows) a no-op.
+    /// </summary>
+    internal void RegisterScheme(string scheme)
+    {
+        if (string.IsNullOrEmpty(scheme) || !_registeredSchemes.Add(scheme))
+            return;
+        Span<byte> buf = stackalloc byte[64];
+        var str = Utf8String.Create(scheme, buf);
+        Saucer.saucer_webview_register_scheme(str.Pointer);
+        str.Dispose();
+    }
+
+    /// <summary>
+    /// Marshals a native operation onto saucer's UI thread. Native window/AppKit calls are not thread-safe, so
+    /// mutating operations are posted to the application loop. A no-op before the app exists or after teardown.
+    /// </summary>
+    internal void RunOnUi(Action action)
+    {
+        if (_disposed || _app == null)
+            return;
+
+        var data = (nint)NativeCallbackHelper.Alloc(new PostedAppAction(this, action));
+        // Track the handle so DisposeNative can reclaim it if saucer drops the posted callback at shutdown
+        // (INT-10). RunPostedAppAction claims-and-removes it before freeing, so the two never double-free.
+        _postedHandles[data] = 0;
+        Saucer.saucer_application_post(
+            _app,
+            (delegate* unmanaged[Cdecl]<void*, void>)&RunPostedAppAction,
+            (void*)data);
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void RunPostedAppAction(void* userdata)
+    {
+        var handle = (nint)userdata;
+        var payload = NativeCallbackHelper.Resolve<PostedAppAction>(userdata);
+        // Claim the handle so a DisposeNative racing at shutdown can't also free it; whoever removes it frees.
+        if (!payload.Owner._postedHandles.TryRemove(handle, out _))
+            return;
+        NativeGuard.Invoke("NativeAppHost.RunOnUi", payload.Action);
+        NativeCallbackHelper.Free(userdata);
+    }
+
+    /// <summary>Pairs a UI-thread action with its owning host so the static native callback can deregister the
+    /// tracked GCHandle (INT-10) before running and freeing it.</summary>
+    private sealed record PostedAppAction(NativeAppHost Owner, Action Action);
+
+    /// <summary>
+    /// True when the caller is already on saucer's UI thread, so UI-thread work can run inline rather than be
+    /// posted. Backed by <c>saucer_application_thread_safe</c>. False before the app exists or after teardown.
+    /// </summary>
+    internal bool IsOnUiThread => _app != null && !_disposed && Saucer.saucer_application_thread_safe(_app) != 0;
+
+    /// <summary>
+    /// Runs <paramref name="action"/> on the UI thread, used by <see cref="IMainThreadDispatcher"/> to fence
+    /// native UI calls made from worker threads (Cluster C / INT-02). Runs inline when already on the UI thread;
+    /// queues it when the native app is not up yet (drained in submission order once the loop starts); otherwise
+    /// posts via saucer. Safe to call from any thread. A no-op after disposal.
+    /// </summary>
+    internal void PostToUi(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        if (_disposed)
+            return;
+
+        if (IsOnUiThread)
+        {
+            NativeGuard.Invoke("NativeAppHost.PostToUi", action);
+            return;
+        }
+
+        // Native app not up yet → buffer until the loop drains the queue on the UI thread. Double-check
+        // _appReady under the lock to close the race with FlushPreReadyQueue (which flips it while holding the
+        // gate): if the app became ready between our volatile read and taking the lock, fall through to post.
+        if (!_appReady)
+        {
+            lock (_preReadyGate)
+            {
+                if (!_appReady && _preReadyQueue is { } queue)
+                {
+                    queue.Add(action);
+                    return;
+                }
+            }
+        }
+
+        RunOnUi(action);
+    }
+
+    /// <summary>
+    /// Like <see cref="PostToUi"/> but returns a Task that completes when the action has run on the UI thread
+    /// (or faults if it throws). Completes inline when already on the UI thread; completes without running if
+    /// the host has been disposed. Used by <see cref="IMainThreadDispatcher.InvokeAsync"/>.
+    /// </summary>
+    internal Task InvokeOnUiAsync(Action action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        if (_disposed)
+            return Task.CompletedTask;
+
+        if (IsOnUiThread)
+        {
+            try { action(); return Task.CompletedTask; }
+            catch (Exception ex) when (ex is not OutOfMemoryException) { return Task.FromException(ex); }
+        }
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        PostToUi(() =>
+        {
+            try { action(); tcs.TrySetResult(); }
+            catch (Exception ex) when (ex is not OutOfMemoryException) { tcs.TrySetException(ex); }
+        });
+        return tcs.Task;
+    }
+
+    /// <summary>
+    /// Drains any work buffered by <see cref="PostToUi"/> before the native app existed, in submission order,
+    /// on the UI thread. Flips <c>_appReady</c> under the gate so a concurrent <see cref="PostToUi"/> either
+    /// lands in the queue we snapshot here or takes the post path — never lost, never run twice.
+    /// </summary>
+    private void FlushPreReadyQueue()
+    {
+        List<Action>? pending;
+        lock (_preReadyGate)
+        {
+            pending = _preReadyQueue;
+            _preReadyQueue = null;
+            _appReady = true;
+        }
+
+        if (pending is null)
+            return;
+
+        // We're on the UI thread here (this runs inside saucer's OnReady), so run inline through the same
+        // NativeGuard barrier the posted path uses.
+        foreach (var action in pending)
+            NativeGuard.Invoke("NativeAppHost.PostToUi", action);
+    }
+
+    /// <summary>
+    /// Frees native handles after the run loop returns: each window's webview/window, the leftover posted
+    /// GCHandles saucer never drained (INT-10), then the application handle. Called from <see cref="Run"/>.
+    /// </summary>
+    private void DisposeNative()
+    {
+        foreach (var window in Windows)
+            window.DisposeNative();
+        lock (_windowsGate)
+        {
+            _windows.Clear();
+            _mainWindow = null;
+        }
+
+        // Reclaim any GCHandles saucer never drained — RunPostedAppAction is what normally frees them, so
+        // without this they leak (INT-10). The TryRemove claim means a callback that did run can't be
+        // double-freed here.
+        foreach (var handle in _postedHandles.Keys)
+        {
+            if (_postedHandles.TryRemove(handle, out _))
+                NativeCallbackHelper.Free(handle);
+        }
+
+        if (_selfHandle != null) { NativeCallbackHelper.Free(_selfHandle); _selfHandle = null; }
+        if (_app != null) { Saucer.saucer_application_free(_app); _app = null; }
+    }
+
+    /// <summary>
+    /// Early/abnormal managed teardown (disposing without ever running, or after a throw). Disposes each
+    /// window's managed resources and cancels its close TCS. Native handle frees happen inside the run loop
+    /// (<see cref="DisposeNative"/>) when the loop runs, so this path only manages the never-ran case.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        // Defensive: Run() disposes the registration after the loop exits, but disposing here too (a no-op on a
+        // default registration) ensures a token cancellation after Dispose can never quit a freed app (PAP-14).
+        _quitRegistration.Dispose();
+        foreach (var window in Windows)
+            window.Dispose();
+    }
+}

--- a/src/Ryn.Core/Internal/NativeAppHost.cs
+++ b/src/Ryn.Core/Internal/NativeAppHost.cs
@@ -46,7 +46,10 @@ internal sealed unsafe class NativeAppHost : IDisposable
     private readonly object _windowsGate = new();
     private readonly Dictionary<int, RynWindow> _windows = [];
     private int _nextWindowId;
-    private RynWindow? _mainWindow;
+    // Id of the first (main) window. Tracked by id rather than a reference so MainWindow naturally reports null
+    // once the main window has closed, and so this class holds no IDisposable window field of its own (the
+    // registry owns the windows and disposes them).
+    private int _mainWindowId;
 
     // Schemes already registered with the engine. saucer_webview_register_scheme is process-global and must
     // run once, before the first webview is created; a double-register is a silent no-op but we guard anyway.
@@ -60,10 +63,10 @@ internal sealed unsafe class NativeAppHost : IDisposable
     /// <summary>True while the native application exists and the host has not begun teardown.</summary>
     internal bool IsRunning => _app != null && !_disposed;
 
-    /// <summary>The first (main) window, once created in OnReady. Null before then.</summary>
+    /// <summary>The first (main) window, once created in OnReady. Null before it exists or after it closes.</summary>
     internal RynWindow? MainWindow
     {
-        get { lock (_windowsGate) return _mainWindow; }
+        get { lock (_windowsGate) return _windows.TryGetValue(_mainWindowId, out var window) ? window : null; }
     }
 
     /// <summary>A point-in-time snapshot of the live windows.</summary>
@@ -84,6 +87,11 @@ internal sealed unsafe class NativeAppHost : IDisposable
     internal void Run(CancellationToken cancellationToken)
     {
         NativeLibraryResolver.Register();
+        // Opt out of macOS App Nap so posted UI work (e.g. opening a window from a background thread) and
+        // webview rendering keep running when the app is not the foreground app, instead of stalling until it
+        // is reactivated.
+        if (OperatingSystem.IsMacOS())
+            MacOsAppNap.Disable();
         Span<byte> idBuf = stackalloc byte[256];
         var appIdStr = Utf8String.Create(_mainWindowOptions.ApplicationId, idBuf);
         var appOpts = Saucer.saucer_application_options_new(appIdStr.Pointer);
@@ -139,7 +147,7 @@ internal sealed unsafe class NativeAppHost : IDisposable
     {
         NativeReady?.Invoke((nint)_app);
 
-        var main = CreateWindowCore(_mainWindowOptions);
+        var main = CreateWindowCore(_mainWindowOptions, isMain: true);
         if (CommandHandler is not null) main.SetCommandHandler(CommandHandler);
         main.InitializeNative();
 
@@ -160,15 +168,64 @@ internal sealed unsafe class NativeAppHost : IDisposable
         NativeGuard.Invoke("NativeAppHost.OnFinish", () => self.CompleteAllCloseSignals());
     }
 
+    /// <summary>
+    /// Opens a new window, blocking until it is created on the UI thread. Short-circuits to an inline create
+    /// when already on the UI thread (re-entrancy from a window-event handler), otherwise marshals the create
+    /// and waits for the result. Safe to call from any thread while the loop is running.
+    /// </summary>
+    internal IRynWindow OpenWindow(RynWindowOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (!IsRunning)
+            throw new InvalidOperationException("Cannot open a window before the application loop is running.");
+        if (IsOnUiThread)
+            return OpenWindowOnUiThread(options);
+
+        IRynWindow? result = null;
+        InvokeOnUiAsync(() => result = OpenWindowOnUiThread(options)).GetAwaiter().GetResult();
+        return result!;
+    }
+
+    /// <summary>Opens a new window without blocking, completing once it has been created on the UI thread.</summary>
+    internal Task<IRynWindow> OpenWindowAsync(RynWindowOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (!IsRunning)
+            throw new InvalidOperationException("Cannot open a window before the application loop is running.");
+        if (IsOnUiThread)
+            return Task.FromResult<IRynWindow>(OpenWindowOnUiThread(options));
+
+        var tcs = new TaskCompletionSource<IRynWindow>(TaskCreationOptions.RunContinuationsAsynchronously);
+        PostToUi(() =>
+        {
+            try { tcs.TrySetResult(OpenWindowOnUiThread(options)); }
+            catch (Exception ex) when (ex is not OutOfMemoryException) { tcs.TrySetException(ex); }
+        });
+        return tcs.Task;
+    }
+
+    private RynWindow OpenWindowOnUiThread(RynWindowOptions options)
+    {
+        var window = CreateWindowCore(options.ToRynOptions(), isMain: false);
+        if (CommandHandler is not null) window.SetCommandHandler(CommandHandler);
+        window.InitializeNative();
+        return window;
+    }
+
     /// <summary>Constructs and registers a window (managed only; native creation is the caller's next step).</summary>
-    private RynWindow CreateWindowCore(RynOptions options)
+    private RynWindow CreateWindowCore(RynOptions options, bool isMain)
     {
         lock (_windowsGate)
         {
             var id = ++_nextWindowId;
-            var window = new RynWindow(this, id, options);
+            // The main window keeps the legacy state key (the application id) so existing state files still load;
+            // a secondary window gets a per-id key so two windows can't corrupt each other's persisted geometry.
+            var stateKey = isMain
+                ? _mainWindowOptions.ApplicationId
+                : $"{_mainWindowOptions.ApplicationId}.window{id.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+            var window = new RynWindow(this, id, options, stateKey);
             _windows[id] = window;
-            _mainWindow ??= window;
+            if (isMain) _mainWindowId = id;
             return window;
         }
     }
@@ -186,8 +243,18 @@ internal sealed unsafe class NativeAppHost : IDisposable
             _windows.Remove(window.Id);
             empty = _windows.Count == 0;
         }
-        if (empty && _app != null)
-            Saucer.saucer_application_quit(_app);
+        if (empty)
+        {
+            // Last window closed: quit the loop. Its native handles are freed by DisposeNative after Run returns.
+            if (_app != null) Saucer.saucer_application_quit(_app);
+        }
+        else
+        {
+            // A secondary window closed while others remain: free its native handles so they don't leak for the
+            // life of the app. Defer to the next UI-thread tick so the free happens after saucer's CLOSED
+            // callback (currently on the stack for this window) has returned.
+            RunOnUi(window.DisposeNative);
+        }
     }
 
     private void CompleteAllCloseSignals()
@@ -372,7 +439,6 @@ internal sealed unsafe class NativeAppHost : IDisposable
         lock (_windowsGate)
         {
             _windows.Clear();
-            _mainWindow = null;
         }
 
         // Reclaim any GCHandles saucer never drained — RunPostedAppAction is what normally frees them, so

--- a/src/Ryn.Core/Internal/NativeAppHost.cs
+++ b/src/Ryn.Core/Internal/NativeAppHost.cs
@@ -223,7 +223,7 @@ internal sealed unsafe class NativeAppHost : IDisposable
             var stateKey = isMain
                 ? _mainWindowOptions.ApplicationId
                 : $"{_mainWindowOptions.ApplicationId}.window{id.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
-            var window = new RynWindow(this, id, options, stateKey);
+            var window = new RynWindow(this, id, options, stateKey, isMain);
             _windows[id] = window;
             if (isMain) _mainWindowId = id;
             return window;

--- a/src/Ryn.Core/Internal/NativeApplicationAccessor.cs
+++ b/src/Ryn.Core/Internal/NativeApplicationAccessor.cs
@@ -1,6 +1,16 @@
 namespace Ryn.Core.Internal;
 
+/// <summary>
+/// Holds process-global native application state for services resolved from DI: the raw application handle
+/// (for advanced native interop) and the live <see cref="NativeAppHost"/>. The host is published by
+/// <see cref="RynApplication.RunAsync"/> before plugins initialize, so <see cref="IMainThreadDispatcher"/>
+/// and <see cref="IRynApplicationLifetime"/> can marshal work onto — and request shutdown of — the one
+/// application/loop even from a plugin backend running before the loop is up.
+/// </summary>
 internal sealed class NativeApplicationAccessor
 {
     internal nint ApplicationHandle { get; set; }
+
+    /// <summary>The live application host, or null before <see cref="RynApplication.RunAsync"/> creates it.</summary>
+    internal NativeAppHost? Host { get; set; }
 }

--- a/src/Ryn.Core/Internal/RynApplicationLifetime.cs
+++ b/src/Ryn.Core/Internal/RynApplicationLifetime.cs
@@ -1,18 +1,18 @@
 namespace Ryn.Core.Internal;
 
 /// <summary>
-/// Default <see cref="IRynApplicationLifetime"/>. Requests an orderly shutdown by closing the live window
-/// through <see cref="RynWindowAccessor"/>, which drives the native event loop to unwind so
-/// <see cref="RynApplication.RunAsync"/> returns and normal disposal runs (PAP-06).
+/// Default <see cref="IRynApplicationLifetime"/>. Requests an orderly shutdown through the live
+/// <see cref="NativeAppHost"/>, which closes every window so the native event loop unwinds,
+/// <see cref="RynApplication.RunAsync"/> returns, and normal disposal runs (PAP-06).
 /// </summary>
 /// <remarks>
-/// Routed through the accessor rather than holding a <see cref="RynApplication"/> reference because the app is
-/// constructed <em>after</em> the DI provider is built, whereas this service is resolvable as soon as the
-/// provider exists. <see cref="RynWindow.RequestClose"/> is itself thread-safe and queues onto the UI thread,
-/// so this is safe to call from any thread (e.g. an updater running on a thread-pool/IPC thread). A no-op if
-/// the window does not exist yet — there is nothing running to shut down.
+/// Routed through <see cref="NativeApplicationAccessor"/> rather than holding a <see cref="RynApplication"/>
+/// reference because the app is constructed <em>after</em> the DI provider is built, whereas this service is
+/// resolvable as soon as the provider exists. The host's shutdown is itself thread-safe and queues onto the UI
+/// thread, so this is safe to call from any thread (e.g. an updater on a thread-pool/IPC thread). A no-op if
+/// the host does not exist yet — there is nothing running to shut down.
 /// </remarks>
-internal sealed class RynApplicationLifetime(RynWindowAccessor accessor) : IRynApplicationLifetime
+internal sealed class RynApplicationLifetime(NativeApplicationAccessor accessor) : IRynApplicationLifetime
 {
-    public void RequestShutdown() => accessor.Window?.RequestClose();
+    public void RequestShutdown() => accessor.Host?.RequestShutdown();
 }

--- a/src/Ryn.Core/Internal/RynWindowManager.cs
+++ b/src/Ryn.Core/Internal/RynWindowManager.cs
@@ -1,0 +1,27 @@
+namespace Ryn.Core.Internal;
+
+/// <summary>
+/// Default <see cref="IRynWindowManager"/>. Forwards to the live <see cref="NativeAppHost"/> via
+/// <see cref="NativeApplicationAccessor"/>, so it is resolvable from DI before the loop is up and never holds a
+/// stale window reference. Throws on open while the application is not running; reports an empty window list.
+/// </summary>
+internal sealed class RynWindowManager(NativeApplicationAccessor accessor) : IRynWindowManager
+{
+    public IRynWindow OpenWindow(RynWindowOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var host = accessor.Host
+            ?? throw new InvalidOperationException("Cannot open a window before the application is running.");
+        return host.OpenWindow(options);
+    }
+
+    public Task<IRynWindow> OpenWindowAsync(RynWindowOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var host = accessor.Host
+            ?? throw new InvalidOperationException("Cannot open a window before the application is running.");
+        return host.OpenWindowAsync(options);
+    }
+
+    public IReadOnlyList<IRynWindow> Windows => accessor.Host?.Windows ?? [];
+}

--- a/src/Ryn.Core/RynApplication.cs
+++ b/src/Ryn.Core/RynApplication.cs
@@ -12,7 +12,7 @@ public sealed partial class RynApplication : IAsyncDisposable
     private readonly IServiceProvider _services;
     private readonly ILogger<RynApplication> _logger;
     private readonly List<IRynPlugin> _plugins = [];
-    private RynWindow? _window;
+    private NativeAppHost? _host;
     private volatile bool _running;
     private bool _disposed;
 
@@ -34,11 +34,11 @@ public sealed partial class RynApplication : IAsyncDisposable
     /// <summary>The dependency injection service provider for this application.</summary>
     public IServiceProvider Services => _services;
 
-    /// <summary>The application window. Only available after <see cref="RunAsync"/> has been called.</summary>
-    public IRynWindow Window => _window ?? throw new InvalidOperationException("Application is not running");
+    /// <summary>The main application window. Only available after <see cref="RunAsync"/> has been called.</summary>
+    public IRynWindow Window => _host?.MainWindow ?? throw new InvalidOperationException("Application is not running");
 
-    /// <summary>The application webview. Only available after <see cref="RunAsync"/> has been called.</summary>
-    public IRynWebView WebView => _window?.WebView ?? throw new InvalidOperationException("Application is not running");
+    /// <summary>The main application webview. Only available after <see cref="RunAsync"/> has been called.</summary>
+    public IRynWebView WebView => _host?.MainWindow?.WebView ?? throw new InvalidOperationException("Application is not running");
 
     /// <summary>Creates a new application builder with default options.</summary>
     public static RynApplicationBuilder CreateBuilder() => new(programmaticOptions: null);
@@ -152,20 +152,19 @@ public sealed partial class RynApplication : IAsyncDisposable
                     RaiseDeepLink(deepLink);
             }
 
-            _window = new RynWindow(options);
+            var host = new NativeAppHost(options);
+            _host = host;
 
-            // Wire IPC command dispatcher if registered (before Run, applied during OnReady)
-            var commandHandler = _services.GetService<CommandDispatchHandler>();
-            if (commandHandler is not null)
-            {
-                _window.SetCommandHandler(commandHandler);
-            }
+            // Wire IPC command dispatcher if registered. The host applies it to the main window's webview
+            // during OnReady, before the window is initialized.
+            host.CommandHandler = _services.GetService<CommandDispatchHandler>();
 
             var accessor = _services.GetRequiredService<RynWindowAccessor>();
-            accessor.Window = _window;
-
             var nativeAccessor = _services.GetRequiredService<NativeApplicationAccessor>();
-            _window.OnNativeReady = handle => nativeAccessor.ApplicationHandle = handle;
+            host.NativeReady = handle => nativeAccessor.ApplicationHandle = handle;
+            // Publish the live main window once it is fully initialized (inside OnReady, on the UI thread) so
+            // deferred IRynWindow/IRynWebView injections and queued main-thread work resolve against it.
+            host.MainWindowCreated = window => accessor.Window = window;
 
             Log.Running(_logger);
 
@@ -177,7 +176,7 @@ public sealed partial class RynApplication : IAsyncDisposable
 
             try
             {
-                _window.Run(cts.Token);
+                host.Run(cts.Token);
             }
             catch (Exception ex) when (ex is not OperationCanceledException && ex is not OutOfMemoryException)
             {
@@ -263,10 +262,10 @@ public sealed partial class RynApplication : IAsyncDisposable
         if (_disposed)
             return;
 
-        // Closing the window drives the native CLOSE/CLOSED path → saucer_application_quit → loop returns. If the
-        // window object does not exist yet (RequestShutdown raced ahead of RunAsync creating it) there is nothing
-        // running to stop, so this is a no-op — RunAsync has not begun the loop and will exit on its own.
-        _window?.RequestClose();
+        // Closing every window drives the native CLOSE/CLOSED path → the last close quits the loop → RunAsync
+        // returns. If the host does not exist yet (RequestShutdown raced ahead of RunAsync creating it) there is
+        // nothing running to stop, so this is a no-op — RunAsync has not begun the loop and will exit on its own.
+        _host?.RequestShutdown();
     }
 
     internal void AddPlugin(IRynPlugin plugin) => _plugins.Add(plugin);
@@ -318,17 +317,17 @@ public sealed partial class RynApplication : IAsyncDisposable
             }
         }
 
-        // 2. Window (which internally frees webview → native window → native application, in that order).
-        //    Only when the loop is NOT live: while RunAsync's event loop is still pumping it owns those native
-        //    handles and frees them itself as it unwinds (RynWindow.DisposeNative after the loop exits), so
-        //    freeing them here would race that teardown and risk freeing a live handle mid-flight. In that
-        //    case leave the window alone — closing the window or cancelling RunAsync's token is the supported
-        //    way to stop a running app — and only manage plugin/service disposal.
-        var window = _window;
+        // 2. Application host (which internally disposes each window's webview → native window, then frees the
+        //    native application, in that order). Only when the loop is NOT live: while RunAsync's event loop is
+        //    still pumping it owns those native handles and frees them itself as it unwinds (NativeAppHost's
+        //    DisposeNative after the loop exits), so freeing them here would race that teardown and risk freeing
+        //    a live handle mid-flight. In that case leave the host alone — closing the windows or cancelling
+        //    RunAsync's token is the supported way to stop a running app — and only manage plugin/service disposal.
+        var host = _host;
         if (!_running)
         {
-            _window = null;
-            window?.Dispose();
+            _host = null;
+            host?.Dispose();
         }
 
         // 3. App/services last.

--- a/src/Ryn.Core/RynApplication.cs
+++ b/src/Ryn.Core/RynApplication.cs
@@ -34,8 +34,16 @@ public sealed partial class RynApplication : IAsyncDisposable
     /// <summary>The dependency injection service provider for this application.</summary>
     public IServiceProvider Services => _services;
 
-    /// <summary>The main application window. Only available after <see cref="RunAsync"/> has been called.</summary>
-    public IRynWindow Window => _host?.MainWindow ?? throw new InvalidOperationException("Application is not running");
+    /// <summary>The main application window — the first window opened. Only available after
+    /// <see cref="RunAsync"/> has been called.</summary>
+    public IRynWindow MainWindow => _host?.MainWindow ?? throw new InvalidOperationException("Application is not running");
+
+    /// <summary>The main application window. Alias of <see cref="MainWindow"/> kept for source compatibility.</summary>
+    public IRynWindow Window => MainWindow;
+
+    /// <summary>All currently-open windows, main first. Empty before <see cref="RunAsync"/> has opened the main
+    /// window; never throws, so it is safe to enumerate at any point.</summary>
+    public IReadOnlyList<IRynWindow> Windows => _host?.Windows ?? [];
 
     /// <summary>The main application webview. Only available after <see cref="RunAsync"/> has been called.</summary>
     public IRynWebView WebView => _host?.MainWindow?.WebView ?? throw new InvalidOperationException("Application is not running");
@@ -106,6 +114,26 @@ public sealed partial class RynApplication : IAsyncDisposable
 
         try
         {
+            var options = _services.GetRequiredService<RynOptions>();
+
+            // Create and publish the host BEFORE plugins initialize, so a plugin backend that resolves
+            // IMainThreadDispatcher / IRynApplicationLifetime during its InitializeAsync marshals onto (and can
+            // request shutdown of) the real host. The host buffers pre-loop work and drains it on the UI thread
+            // once the loop starts (Cluster C / INT-02). No native work happens until host.Run.
+            var host = new NativeAppHost(options);
+            _host = host;
+
+            var accessor = _services.GetRequiredService<RynWindowAccessor>();
+            var nativeAccessor = _services.GetRequiredService<NativeApplicationAccessor>();
+            nativeAccessor.Host = host;
+            host.NativeReady = handle => nativeAccessor.ApplicationHandle = handle;
+            // Wire IPC command dispatcher if registered. The host applies it to the main window's webview
+            // during OnReady, before the window is initialized.
+            host.CommandHandler = _services.GetService<CommandDispatchHandler>();
+            // Publish the live main window once it is fully initialized (inside OnReady, on the UI thread) so
+            // deferred IRynWindow/IRynWebView injections and queued main-thread work resolve against it.
+            host.MainWindowCreated = window => accessor.Window = window;
+
             foreach (var plugin in _plugins)
             {
                 try
@@ -122,8 +150,6 @@ public sealed partial class RynApplication : IAsyncDisposable
                     Log.PluginInitFailed(_logger, plugin.Name, ex);
                 }
             }
-
-            var options = _services.GetRequiredService<RynOptions>();
 
             // Opt-in process-global exception net: log and surface AppDomain / unobserved-task exceptions
             // via the UnhandledException event so apps can install a crash logger.
@@ -151,20 +177,6 @@ public sealed partial class RynApplication : IAsyncDisposable
                 if (deepLink is not null)
                     RaiseDeepLink(deepLink);
             }
-
-            var host = new NativeAppHost(options);
-            _host = host;
-
-            // Wire IPC command dispatcher if registered. The host applies it to the main window's webview
-            // during OnReady, before the window is initialized.
-            host.CommandHandler = _services.GetService<CommandDispatchHandler>();
-
-            var accessor = _services.GetRequiredService<RynWindowAccessor>();
-            var nativeAccessor = _services.GetRequiredService<NativeApplicationAccessor>();
-            host.NativeReady = handle => nativeAccessor.ApplicationHandle = handle;
-            // Publish the live main window once it is fully initialized (inside OnReady, on the UI thread) so
-            // deferred IRynWindow/IRynWebView injections and queued main-thread work resolve against it.
-            host.MainWindowCreated = window => accessor.Window = window;
 
             Log.Running(_logger);
 

--- a/src/Ryn.Core/RynApplication.cs
+++ b/src/Ryn.Core/RynApplication.cs
@@ -48,6 +48,20 @@ public sealed partial class RynApplication : IAsyncDisposable
     /// <summary>The main application webview. Only available after <see cref="RunAsync"/> has been called.</summary>
     public IRynWebView WebView => _host?.MainWindow?.WebView ?? throw new InvalidOperationException("Application is not running");
 
+    /// <summary>
+    /// Opens a new window and returns it. Safe to call from any thread; native window creation is marshalled
+    /// onto the UI thread and the call blocks until the window exists. Throws if the application is not running.
+    /// </summary>
+    public IRynWindow OpenWindow(RynWindowOptions options) =>
+        (_host ?? throw new InvalidOperationException("Application is not running")).OpenWindow(options);
+
+    /// <summary>
+    /// Opens a new window without blocking, completing once it has been created on the UI thread. Throws if the
+    /// application is not running.
+    /// </summary>
+    public Task<IRynWindow> OpenWindowAsync(RynWindowOptions options) =>
+        (_host ?? throw new InvalidOperationException("Application is not running")).OpenWindowAsync(options);
+
     /// <summary>Creates a new application builder with default options.</summary>
     public static RynApplicationBuilder CreateBuilder() => new(programmaticOptions: null);
 

--- a/src/Ryn.Core/RynApplicationBuilder.cs
+++ b/src/Ryn.Core/RynApplicationBuilder.cs
@@ -149,8 +149,8 @@ public sealed class RynApplicationBuilder
         // resolve them; a user registration of the same interface still overrides via last-wins.
         // - IMainThreadDispatcher: marshal native UI calls (tray/audio AppKit work) onto the main thread.
         // - IRynApplicationLifetime: request orderly shutdown (updater relaunch) instead of Environment.Exit.
-        _services.AddSingleton<IMainThreadDispatcher>(sp => new MainThreadDispatcher(sp.GetRequiredService<RynWindowAccessor>()));
-        _services.AddSingleton<IRynApplicationLifetime>(sp => new RynApplicationLifetime(sp.GetRequiredService<RynWindowAccessor>()));
+        _services.AddSingleton<IMainThreadDispatcher>(sp => new MainThreadDispatcher(sp.GetRequiredService<NativeApplicationAccessor>()));
+        _services.AddSingleton<IRynApplicationLifetime>(sp => new RynApplicationLifetime(sp.GetRequiredService<NativeApplicationAccessor>()));
 
         // 5. User service configuration
         foreach (var configure in _configureActions)

--- a/src/Ryn.Core/RynApplicationBuilder.cs
+++ b/src/Ryn.Core/RynApplicationBuilder.cs
@@ -152,6 +152,12 @@ public sealed class RynApplicationBuilder
         _services.AddSingleton<IMainThreadDispatcher>(sp => new MainThreadDispatcher(sp.GetRequiredService<NativeApplicationAccessor>()));
         _services.AddSingleton<IRynApplicationLifetime>(sp => new RynApplicationLifetime(sp.GetRequiredService<NativeApplicationAccessor>()));
 
+        // Multi-window: resolve the originating window of an IPC command (window.* commands act on it) and open
+        // new windows at runtime. Both forward to the live host via the accessor, so they are resolvable from
+        // DI before the loop is up and never hold a stale reference.
+        _services.AddSingleton<CurrentWindowAccessor>(sp => new CurrentWindowAccessor(sp.GetRequiredService<NativeApplicationAccessor>()));
+        _services.AddSingleton<IRynWindowManager>(sp => new RynWindowManager(sp.GetRequiredService<NativeApplicationAccessor>()));
+
         // 5. User service configuration
         foreach (var configure in _configureActions)
         {

--- a/src/Ryn.Core/RynWebView.cs
+++ b/src/Ryn.Core/RynWebView.cs
@@ -213,6 +213,11 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
 
     private CommandDispatchHandler? _commandHandler;
 
+    // The window that owns this webview, stamped onto each IPC dispatch as the ambient "current window" so
+    // window.* commands act on the originating window rather than always on the main window. Null for a webview
+    // not attached to a window (defensive; production always sets it in RynWindow.InitializeNative).
+    private IRynWindow? _owningWindow;
+
     /// <inheritdoc />
     public event EventHandler<FileDropEventArgs>? FileDrop;
 
@@ -250,6 +255,9 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
     }
 
     internal void SetCommandHandler(CommandDispatchHandler handler) => _commandHandler = handler;
+
+    /// <summary>Records the window that owns this webview, so IPC commands from its page can be routed back to it.</summary>
+    internal void SetOwningWindow(IRynWindow window) => _owningWindow = window;
 
     Task<(bool Ok, string Data)> Internal.ILocalServerHost.DispatchCommandFromServerAsync(string command, string body)
         => ExecuteCommandAsync(command, Encoding.UTF8.GetBytes(body));
@@ -599,16 +607,19 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
             return;
         }
 
-        // IPC endpoints (cmd/eval) are privileged: enforce the per-launch token, require POST, and treat a
-        // missing Origin as denied (IPC-01). The bridge always sends the token + POST, so legitimate calls
-        // are unaffected; a no-Origin GET (e.g. an <img>/iframe probe) and any wrong/absent token are
-        // rejected instead of being mapped onto the app origin. The token check is constant-time.
+        // IPC endpoints (cmd/eval) are privileged: enforce the per-launch token and require POST. The token is
+        // the real security boundary — only the bridge injected into the app's own same-origin page receives
+        // it (IPC-01). WebKit sends NO Origin header for same-origin custom-scheme (ryn://) requests, so the
+        // legitimate in-page bridge call arrives with no Origin; requiring one would deny every same-origin IPC
+        // call. So a MISSING Origin is allowed (the token gates it), while a PRESENT Origin must be on the
+        // allowlist — a genuinely cross-origin caller (which also lacks the token) is still rejected. The token
+        // check is constant-time.
         if (isIpc)
         {
             var presentedToken = ParseHeaderValue(headers, IpcProtocol.TokenHeader);
+            var originAllowed = requestOrigin is null || matchedOrigin is not null;
             var authorized =
-                requestOrigin is not null              // null Origin is denied for /ipc/
-                && matchedOrigin is not null           // origin must be on the allowlist
+                originAllowed
                 && string.Equals(method, "POST", StringComparison.OrdinalIgnoreCase)
                 && TokenMatches(presentedToken);
             if (!authorized)
@@ -758,6 +769,11 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
 
         if (_commandHandler is null)
             return (true, "null");
+
+        // Publish the originating window into the ambient slot BEFORE the Task.Run hop, so it flows into the
+        // dispatched command via the captured ExecutionContext and window.* commands act on THIS window. Each
+        // call has its own async slot, so concurrent dispatches from different windows never collide.
+        Internal.CurrentWindow.Value = _owningWindow;
 
         try
         {
@@ -1084,15 +1100,21 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
         return value;
     }
 
-    /// <summary>Reads a single header value out of saucer's newline-separated <c>Name: value</c> header blob.</summary>
+    // saucer concatenates request headers as NUL-separated "Name: value" pairs ("\0"); some transports use
+    // CRLF/LF instead. Split on all of them so a single header value is found regardless of the engine's
+    // delimiter — splitting only on '\n' (the old assumption) collapsed the whole blob into one line and
+    // never matched anything but the first header, silently failing the IPC token/origin checks.
+    private static readonly char[] HeaderSeparators = ['\0', '\n', '\r'];
+
+    /// <summary>Reads a single header value out of saucer's NUL/newline-separated <c>Name: value</c> header blob.</summary>
     private static string? ParseHeaderValue(string headers, string name)
     {
-        foreach (var line in headers.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        foreach (var line in headers.Split(HeaderSeparators, StringSplitOptions.RemoveEmptyEntries))
         {
             var colon = line.IndexOf(':', StringComparison.Ordinal);
             if (colon <= 0) continue;
             if (line.AsSpan(0, colon).Trim().Equals(name, StringComparison.OrdinalIgnoreCase))
-                return line[(colon + 1)..].Trim().TrimEnd('\r');
+                return line[(colon + 1)..].Trim();
         }
         return null;
     }

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -83,7 +83,7 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     }
 
     /// <summary>Stable per-application window identifier, assigned by the host when the window is created.</summary>
-    internal int Id { get; }
+    public int Id { get; }
 
     internal void SetCommandHandler(CommandDispatchHandler handler) => _commandHandler = handler;
 

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Ryn.Core.Internal;
@@ -8,10 +7,13 @@ namespace Ryn.Core;
 
 public sealed unsafe class RynWindow : IRynWindow, IDisposable
 {
+    // The application host that owns the native saucer_application, the run loop, and the UI-thread
+    // marshalling. Per-window operations delegate their post/quit/scheme-registration through it. Null only
+    // for a standalone test instance constructed without a host (no native work is ever issued in that case).
+    private readonly NativeAppHost? _host;
     private readonly RynOptions _options;
     private readonly TaskCompletionSource _closeTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    private saucer_application* _app;
     private saucer_window* _window;
     private saucer_webview* _webview;
     private void* _selfHandle;
@@ -37,24 +39,6 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     private int _normalWidth;
     private int _normalHeight;
     private volatile bool _disposed;
-
-    // GCHandles posted to saucer's UI thread via RunOnUi. RunPostedWindowAction normally claims-and-frees
-    // each one; tracking them here lets DisposeNative reclaim any the run loop dropped at shutdown (INT-10),
-    // mirroring RynWebView._postedCallbacks.
-    private readonly ConcurrentDictionary<nint, byte> _postedHandles = new();
-
-    // Main-thread work submitted (via IMainThreadDispatcher) before the native application exists. saucer's
-    // post requires a live _app, so RunOnUi drops actions while _app == null. Buffer them here and drain them
-    // — in submission order, on the UI thread — once InitializeNative brings the app up, so a plugin backend
-    // (tray/audio) that fences AppKit calls during its InitializeAsync still has them run on the main thread
-    // rather than silently dropped (Cluster C / INT-02). Guarded by _preReadyGate; nulled after the drain so
-    // later posts go straight to RunOnUi. Drained on the UI thread inside InitializeNative.
-    private readonly object _preReadyGate = new();
-    private List<Action>? _preReadyQueue = [];
-    private volatile bool _appReady;
-
-    // Disposed after the saucer run loop exits so a late token cancellation can't quit a freed _app (PAP-14).
-    private CancellationTokenRegistration _quitRegistration;
 
     /// <inheritdoc />
     public event EventHandler<WindowClosingEventArgs>? Closing;
@@ -83,8 +67,14 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     /// <inheritdoc />
     public AppTheme Theme => _themeDetector?.Current ?? SystemThemeDetector.Detect();
 
-    internal RynWindow(RynOptions options)
+    /// <summary>Constructs a standalone window with no application host. Native operations are inert; used by
+    /// tests that exercise the managed surface (events, accessor wiring) without a running event loop.</summary>
+    internal RynWindow(RynOptions options) : this(host: null, id: 0, options) { }
+
+    internal RynWindow(NativeAppHost? host, int id, RynOptions options)
     {
+        _host = host;
+        Id = id;
         _options = options;
         _cachedTitle = options.Title;
         _cachedWidth = options.Width;
@@ -92,9 +82,14 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         _cachedResizable = options.Resizable;
     }
 
-    internal Action<nint>? OnNativeReady { get; set; }
+    /// <summary>Stable per-application window identifier, assigned by the host when the window is created.</summary>
+    internal int Id { get; }
 
     internal void SetCommandHandler(CommandDispatchHandler handler) => _commandHandler = handler;
+
+    /// <summary>Completes the window's close signal so <see cref="WaitForCloseAsync"/> awaiters unblock. Used
+    /// by the host's OnFinish/startup-failure paths to defensively release a still-open waiter.</summary>
+    internal void CompleteCloseSignal() => _closeTcs.TrySetResult();
 
     public IRynWebView WebView => _rynWebView ?? throw new InvalidOperationException("Window not initialized");
 
@@ -184,8 +179,15 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     internal void RequestClose() => PostToUi(() =>
     {
         if (_window != null) Saucer.saucer_window_close(_window);
-        else if (_app != null) Saucer.saucer_application_quit(_app);
+        else _host?.Quit();
     });
+
+    /// <summary>Closes the native window. Must be called on the UI thread (used by host-driven shutdown). A
+    /// no-op before the native window exists.</summary>
+    internal void CloseNativeWindow()
+    {
+        if (_window != null) Saucer.saucer_window_close(_window);
+    }
 
     public void Minimize() => RunOnUi(() => { if (_window != null) Saucer.saucer_window_set_minimized(_window, 1); });
 
@@ -203,40 +205,16 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     public void StartResize(WindowEdge edge) => RunOnUi(() => { if (_window != null) Saucer.saucer_window_start_resize(_window, (saucer_window_edge)edge); });
 
     /// <summary>
-    /// Marshals a native window operation onto saucer's UI thread. Native window/AppKit calls are not
-    /// thread-safe, so all mutating operations are posted to the application loop (a no-op deferral when
-    /// already on the UI thread). Safe to call from any thread.
+    /// Marshals a native window operation onto saucer's UI thread via the application host. Native
+    /// window/AppKit calls are not thread-safe, so mutating operations are posted to the application loop
+    /// (a no-op deferral when already on the UI thread). Safe to call from any thread; inert without a host.
     /// </summary>
-    private unsafe void RunOnUi(Action action)
+    private void RunOnUi(Action action)
     {
-        if (_disposed || _app == null)
+        if (_disposed)
             return;
-
-        var data = (nint)NativeCallbackHelper.Alloc(new PostedWindowAction(this, action));
-        // Track the handle so DisposeNative can reclaim it if saucer drops the posted callback at shutdown
-        // (INT-10). RunPostedWindowAction claims-and-removes it before freeing, so the two never double-free.
-        _postedHandles[data] = 0;
-        Saucer.saucer_application_post(
-            _app,
-            (delegate* unmanaged[Cdecl]<void*, void>)&RunPostedWindowAction,
-            (void*)data);
+        _host?.RunOnUi(action);
     }
-
-    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
-    private static unsafe void RunPostedWindowAction(void* userdata)
-    {
-        var handle = (nint)userdata;
-        var payload = NativeCallbackHelper.Resolve<PostedWindowAction>(userdata);
-        // Claim the handle so a DisposeNative racing at shutdown can't also free it; whoever removes it frees.
-        if (!payload.Owner._postedHandles.TryRemove(handle, out _))
-            return;
-        NativeGuard.Invoke("RynWindow.RunOnUi", payload.Action);
-        NativeCallbackHelper.Free(userdata);
-    }
-
-    /// <summary>Pairs a UI-thread action with its owning window, so the static native callback can deregister
-    /// the tracked GCHandle (INT-10) before running and freeing it.</summary>
-    private sealed record PostedWindowAction(RynWindow Owner, Action Action);
 
     /// <summary>
     /// Like <see cref="RunOnUi"/> but returns a Task that completes when the posted action has actually run
@@ -245,7 +223,7 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     /// </summary>
     private Task RunOnUiAsync(Action action)
     {
-        if (_disposed || _app == null)
+        if (_disposed || _host is not { IsRunning: true })
             return Task.CompletedTask;
 
         var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -258,182 +236,54 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     }
 
     /// <summary>
-    /// True when the caller is already on saucer's UI thread, so UI-thread work can run inline rather than be
-    /// posted. Backed by <c>saucer_application_thread_safe</c>, which returns non-zero on the thread that owns
-    /// the application/event loop. False before the app exists or after it is torn down (treat as "off thread"
-    /// — the safe default is to post/queue, never to run native UI work inline on an unknown thread).
-    /// </summary>
-    private bool IsOnUiThread => _app != null && !_disposed && Saucer.saucer_application_thread_safe(_app) != 0;
-
-    /// <summary>
     /// Runs <paramref name="action"/> on the UI thread, used by <see cref="IMainThreadDispatcher"/> to fence
-    /// native UI calls (tray/audio AppKit work) made from worker threads (Cluster C / INT-02). Runs inline when
-    /// already on the UI thread; queues it when the native app is not up yet (drained in submission order once
-    /// the loop starts); otherwise posts via saucer. Safe to call from any thread. A no-op after disposal.
+    /// native UI calls (tray/audio AppKit work) made from worker threads (Cluster C / INT-02). Delegates to the
+    /// host, which runs inline when already on the UI thread, queues it when the native app is not up yet, or
+    /// posts via saucer otherwise. Safe to call from any thread. A no-op after disposal or without a host.
     /// </summary>
     internal void PostToUi(Action action)
     {
         ArgumentNullException.ThrowIfNull(action);
         if (_disposed)
             return;
-
-        // Already on the UI thread → run inline so ordering relative to surrounding UI work is preserved and
-        // there is no needless deferral. Wrapped in NativeGuard so a throw is routed to the app's
-        // unhandled-exception surface, matching the posted path (RunPostedWindowAction).
-        if (IsOnUiThread)
-        {
-            NativeGuard.Invoke("RynWindow.PostToUi", action);
-            return;
-        }
-
-        // Native app not up yet → buffer until InitializeNative drains the queue on the UI thread. Double-check
-        // _appReady under the lock to close the race with FlushPreReadyQueue (which flips it while holding the
-        // gate): if the app became ready between our volatile read and taking the lock, fall through to post.
-        if (!_appReady)
-        {
-            lock (_preReadyGate)
-            {
-                if (!_appReady && _preReadyQueue is { } queue)
-                {
-                    queue.Add(action);
-                    return;
-                }
-            }
-        }
-
-        RunOnUi(action);
+        _host?.PostToUi(action);
     }
 
     /// <summary>
     /// Like <see cref="PostToUi"/> but returns a Task that completes when the action has run on the UI thread
-    /// (or faults if it throws). Completes inline when already on the UI thread; completes without running if
-    /// the app has been disposed. Used by <see cref="IMainThreadDispatcher.InvokeAsync"/>.
+    /// (or faults if it throws). Used by <see cref="IMainThreadDispatcher.InvokeAsync"/>. Completes without
+    /// running if the window has been disposed or has no host.
     /// </summary>
     internal Task InvokeOnUiAsync(Action action)
     {
         ArgumentNullException.ThrowIfNull(action);
         if (_disposed)
             return Task.CompletedTask;
-
-        if (IsOnUiThread)
-        {
-            try { action(); return Task.CompletedTask; }
-            catch (Exception ex) when (ex is not OutOfMemoryException) { return Task.FromException(ex); }
-        }
-
-        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        PostToUi(() =>
-        {
-            try { action(); tcs.TrySetResult(); }
-            catch (Exception ex) when (ex is not OutOfMemoryException) { tcs.TrySetException(ex); }
-        });
-        return tcs.Task;
+        return _host?.InvokeOnUiAsync(action) ?? Task.CompletedTask;
     }
 
     /// <summary>
-    /// Drains any work buffered by <see cref="PostToUi"/> before the native app existed, in submission order,
-    /// on the UI thread. Called once from <see cref="InitializeNative"/> after the app/window are created.
-    /// Flips <c>_appReady</c> under the gate so a concurrent <see cref="PostToUi"/> either lands in the queue we
-    /// snapshot here or takes the post path — never lost, never run twice.
+    /// Creates the native window and webview, applies options, wires events and content, and shows the window.
+    /// Called by the host on the UI thread (inside OnReady) after the application exists. Throws on a native
+    /// creation failure; the host's OnReady catch quits the loop and surfaces the exception.
     /// </summary>
-    private void FlushPreReadyQueue()
+    internal void InitializeNative()
     {
-        List<Action>? pending;
-        lock (_preReadyGate)
-        {
-            pending = _preReadyQueue;
-            _preReadyQueue = null;
-            _appReady = true;
-        }
-
-        if (pending is null)
-            return;
-
-        // We're on the UI thread here (InitializeNative runs inside saucer's OnReady callback), so run inline
-        // through the same NativeGuard barrier the posted path uses.
-        foreach (var action in pending)
-            NativeGuard.Invoke("RynWindow.PostToUi", action);
-    }
-
-    internal void Run(CancellationToken cancellationToken)
-    {
-        NativeLibraryResolver.Register();
-        Span<byte> idBuf = stackalloc byte[256];
-        var appIdStr = Utf8String.Create(_options.ApplicationId, idBuf);
-        var appOpts = Saucer.saucer_application_options_new(appIdStr.Pointer);
-        appIdStr.Dispose();
-        int error = 0;
-        _app = Saucer.saucer_application_new(appOpts, &error);
-        Saucer.saucer_application_options_free(appOpts);
-        if (_app == null) throw new InvalidOperationException($"Failed to create saucer application (error code: {error})");
-        if (cancellationToken.CanBeCanceled)
-            _quitRegistration = cancellationToken.Register(() => { if (_app != null) Saucer.saucer_application_quit(_app); });
+        var app = _host!.App;
+        // Allocate the per-window GCHandle that backs this window's native event callbacks (CLOSE/CLOSED/…),
+        // freed in DisposeNative. The host owns a separate handle for the app-level OnReady/OnFinish callbacks.
         _selfHandle = NativeCallbackHelper.Alloc(this);
-        var exitCode = Saucer.saucer_application_run(_app,
-            (delegate* unmanaged[Cdecl]<saucer_application*, void*, void>)&OnReady,
-            (delegate* unmanaged[Cdecl]<saucer_application*, void*, void>)&OnFinish,
-            _selfHandle);
-        _ = exitCode;
-        // Dispose the cancellation registration before freeing _app: the registration is only meaningful while
-        // the loop runs, and disposing it here closes the post-shutdown closure pin and the TOCTOU window where
-        // a late cancellation could call saucer_application_quit on the freed _app (PAP-14).
-        _quitRegistration.Dispose();
-        _quitRegistration = default;
-        DisposeNative();
-    }
-
-    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
-    private static void OnReady(saucer_application* app, void* userdata)
-    {
-        var self = NativeCallbackHelper.Resolve<RynWindow>(userdata);
-        NativeGuard.Invoke("RynWindow.OnReady", () =>
-        {
-            try
-            {
-                self.InitializeNative();
-            }
-            catch
-            {
-                // Startup failed (webview/window creation, local-server bind, state-dir creation, …). Quit the
-                // saucer loop so Run() can return and dispose cleanly, then rethrow into NativeGuard, which
-                // routes the exception to RynApplication's UnhandledException surface instead of letting it
-                // fail-fast across the native boundary (ARC-01/INT-01/PAP-09).
-                if (self._app != null) Saucer.saucer_application_quit(self._app);
-                self._closeTcs.TrySetResult();
-                throw;
-            }
-        });
-    }
-
-    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
-    private static void OnFinish(saucer_application* app, void* userdata)
-    {
-        var self = NativeCallbackHelper.Resolve<RynWindow>(userdata);
-        NativeGuard.Invoke("RynWindow.OnFinish", () => self._closeTcs.TrySetResult());
-    }
-
-    private void InitializeNative()
-    {
         int error = 0;
-        _window = Saucer.saucer_window_new(_app, &error);
+        _window = Saucer.saucer_window_new(app, &error);
         if (_window == null) throw new InvalidOperationException($"Failed to create saucer window (error code: {error})");
-        Span<byte> schemeBuf = stackalloc byte[32];
-        var schemeStr = Utf8String.Create("ryn", schemeBuf);
-        Saucer.saucer_webview_register_scheme(schemeStr.Pointer);
-        schemeStr.Dispose();
-        // App-declared custom schemes must be registered with the engine before the webview is created
-        // (saucer silently no-ops handle_scheme for a scheme it wasn't told about pre-creation). The
-        // reserved "ryn" scheme is registered above; skip it here so a stray duplicate can't double-register.
-        // The buffer is hoisted out of the loop (CA2014); Utf8String.Create falls back to a pooled buffer
-        // for any scheme name longer than it, so reusing one stack span across iterations is safe.
-        Span<byte> customSchemeBuf = stackalloc byte[64];
+        // Schemes are registered with the engine process-globally and must exist before the webview is created
+        // (saucer silently no-ops handle_scheme for a scheme it wasn't told about pre-creation). The host
+        // dedupes, so the reserved "ryn" scheme and any scheme shared across windows are registered once.
+        _host.RegisterScheme("ryn");
         foreach (var customScheme in _options.CustomSchemes)
         {
-            if (string.IsNullOrEmpty(customScheme) || string.Equals(customScheme, "ryn", StringComparison.OrdinalIgnoreCase))
-                continue;
-            var customSchemeStr = Utf8String.Create(customScheme, customSchemeBuf);
-            Saucer.saucer_webview_register_scheme(customSchemeStr.Pointer);
-            customSchemeStr.Dispose();
+            if (!string.Equals(customScheme, "ryn", StringComparison.OrdinalIgnoreCase))
+                _host.RegisterScheme(customScheme);
         }
         var webviewOpts = Saucer.saucer_webview_options_new(_window);
         _webview = Saucer.saucer_webview_new(webviewOpts, &error);
@@ -448,7 +298,7 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         _normalY = iy;
         _normalWidth = _cachedWidth;
         _normalHeight = _cachedHeight;
-        _rynWebView = new RynWebView(_webview, _app);
+        _rynWebView = new RynWebView(_webview, app);
         // Tell the webview which schemes were registered with the engine above, so RegisterCustomScheme can
         // attach handlers for them (and reject "ryn"/undeclared schemes). Mirrors the pre-creation loop.
         _rynWebView.SetDeclaredSchemes(_options.CustomSchemes);
@@ -552,12 +402,7 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         }
         else if (_options.ContentDirectory != null) { _rynWebView.SetContentDirectory(_options.ContentDirectory); _rynWebView.NavigateToAppScheme(); }
         else if (_options.Html != null) { _rynWebView.SetHtmlContent(_options.Html); _rynWebView.NavigateToAppScheme(); }
-        OnNativeReady?.Invoke((nint)_app);
         Saucer.saucer_window_show(_window);
-
-        // The native app/window now exist and we're on the UI thread. Drain any main-thread work a plugin
-        // backend buffered via IMainThreadDispatcher before the loop was up (Cluster C / INT-02), in order.
-        FlushPreReadyQueue();
     }
 
     private void ApplyWindowOptions()
@@ -736,7 +581,9 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
             self.SaveWindowState(window);
             self.Closed?.Invoke(self, EventArgs.Empty);
             self._closeTcs.TrySetResult();
-            Saucer.saucer_application_quit(self._app);
+            // Quit the loop only when the last window has closed (the host owns that decision); a multi-window
+            // app keeps running while any other window is open. Replaces the old unconditional quit-on-any-close.
+            self._host?.OnWindowClosedInternal(self);
         });
     }
 
@@ -859,37 +706,29 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         return (Math.Clamp(x, sx, maxX), Math.Clamp(y, sy, maxY));
     }
 
-    private void DisposeNative()
+    /// <summary>
+    /// Frees this window's native handles after the saucer run loop returns: webview, then native window, then
+    /// the per-window GCHandle. The host calls it for each window during its own teardown, then frees the
+    /// application handle. The app-level posted-callback GCHandles are reclaimed by the host (INT-10).
+    /// </summary>
+    internal void DisposeNative()
     {
         if (_localServer is not null) { _localServer.DisposeAsync().AsTask().GetAwaiter().GetResult(); _localServer = null; }
         // Stop the theme poller deterministically once the saucer loop returns, rather than relying on the
-        // public Dispose() (which Run() calls anyway) or the finalizer backstop. This ends the per-tick
-        // child-process probe spawns promptly at teardown (PAP-11/ARC-18). Dispose is idempotent, so the
-        // later Dispose() call is a harmless no-op; nulling the field makes that explicit.
+        // public Dispose() or the finalizer backstop. This ends the per-tick child-process probe spawns
+        // promptly at teardown (PAP-11/ARC-18). Dispose is idempotent, so a later Dispose() call is a harmless
+        // no-op; nulling the field makes that explicit.
         _themeDetector?.Dispose(); _themeDetector = null;
         _rynWebView?.Dispose(); _rynWebView = null;
-        // The saucer run loop has stopped by the time DisposeNative runs (it's called after
-        // saucer_application_run returns), so no RunPostedWindowAction can still fire. Reclaim any GCHandles
-        // saucer never drained — RunPostedWindowAction is what normally frees them, so without this they leak
-        // (INT-10). The TryRemove claim means a callback that did run can't be double-freed here.
-        foreach (var handle in _postedHandles.Keys)
-        {
-            if (_postedHandles.TryRemove(handle, out _))
-                NativeCallbackHelper.Free(handle);
-        }
         if (_webview != null) { Saucer.saucer_webview_free(_webview); _webview = null; }
         if (_window != null) { Saucer.saucer_window_free(_window); _window = null; }
         if (_selfHandle != null) { NativeCallbackHelper.Free(_selfHandle); _selfHandle = null; }
-        if (_app != null) { Saucer.saucer_application_free(_app); _app = null; }
     }
 
     public void Dispose()
     {
         if (_disposed) return;
         _disposed = true;
-        // Defensive: Run() disposes this after the loop exits, but disposing here too (a no-op on a default
-        // registration) ensures a token cancellation after Dispose can never call quit on a freed app (PAP-14).
-        _quitRegistration.Dispose();
         _themeDetector?.Dispose();
         _localServer?.DisposeAsync().AsTask().GetAwaiter().GetResult();
         _rynWebView?.Dispose();

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -67,15 +67,20 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     /// <inheritdoc />
     public AppTheme Theme => _themeDetector?.Current ?? SystemThemeDetector.Detect();
 
+    // Key under which this window's geometry is persisted (when PersistWindowState is enabled). The main window
+    // uses the application id (legacy key); secondary windows use a per-id key to avoid corrupting each other.
+    private readonly string _stateKey;
+
     /// <summary>Constructs a standalone window with no application host. Native operations are inert; used by
     /// tests that exercise the managed surface (events, accessor wiring) without a running event loop.</summary>
-    internal RynWindow(RynOptions options) : this(host: null, id: 0, options) { }
+    internal RynWindow(RynOptions options) : this(host: null, id: 0, options, options.ApplicationId) { }
 
-    internal RynWindow(NativeAppHost? host, int id, RynOptions options)
+    internal RynWindow(NativeAppHost? host, int id, RynOptions options, string stateKey)
     {
         _host = host;
         Id = id;
         _options = options;
+        _stateKey = stateKey;
         _cachedTitle = options.Title;
         _cachedWidth = options.Width;
         _cachedHeight = options.Height;
@@ -200,6 +205,14 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         }
     });
 
+    public void Move(int x, int y) => RunOnUi(() =>
+    {
+        if (_window == null) return;
+        Saucer.saucer_window_set_position(_window, x, y);
+        _cachedX = x; _cachedY = y;
+        if (Saucer.saucer_window_maximized(_window) == 0) { _normalX = x; _normalY = y; }
+    });
+
     public void StartDrag() => RunOnUi(() => { if (_window != null) Saucer.saucer_window_start_drag(_window); });
 
     public void StartResize(WindowEdge edge) => RunOnUi(() => { if (_window != null) Saucer.saucer_window_start_resize(_window, (saucer_window_edge)edge); });
@@ -299,6 +312,9 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         _normalWidth = _cachedWidth;
         _normalHeight = _cachedHeight;
         _rynWebView = new RynWebView(_webview, app);
+        // Stamp the webview with its owning window so an IPC command dispatched from this window's page routes
+        // window.* operations back to THIS window (via the ambient CurrentWindow set in ExecuteCommandAsync).
+        _rynWebView.SetOwningWindow(this);
         // Tell the webview which schemes were registered with the engine above, so RegisterCustomScheme can
         // attach handlers for them (and reject "ryn"/undeclared schemes). Mirrors the pre-creation loop.
         _rynWebView.SetDeclaredSchemes(_options.CustomSchemes);
@@ -324,7 +340,7 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
             // best-effort on Load/Save; this guard is belt-and-suspenders should that ever change.
             try
             {
-                _statePersistence = new WindowStatePersistence(_options.ApplicationId);
+                _statePersistence = new WindowStatePersistence(_stateKey);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
             {
@@ -403,6 +419,25 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         else if (_options.ContentDirectory != null) { _rynWebView.SetContentDirectory(_options.ContentDirectory); _rynWebView.NavigateToAppScheme(); }
         else if (_options.Html != null) { _rynWebView.SetHtmlContent(_options.Html); _rynWebView.NavigateToAppScheme(); }
         Saucer.saucer_window_show(_window);
+        // Re-fit the webview to its window on the NEXT loop tick. A webview created while the event loop is
+        // already running (a secondary window opened via OpenWindow) is added to a window whose content view is
+        // not yet at its final size, so the webview ends up at stale bounds and the window shows only its grey
+        // background. Re-fitting inline here is too early; deferring to the next tick — once the window has been
+        // realized and laid out — sets the correct bounds so the content fills the window. The main window is
+        // already laid out at startup, so this is a harmless no-op for it.
+        _host?.RunOnUi(RefitWebView);
+    }
+
+    /// <summary>
+    /// Re-fits the webview to fill its window's content view, posted to run after the window has been realized.
+    /// A webview created while the event loop is already running (a secondary window opened via OpenWindow) is
+    /// added before the window's content view is at its final size, so without this it can render at stale
+    /// bounds. The main window, laid out at startup, is unaffected.
+    /// </summary>
+    private void RefitWebView()
+    {
+        if (_disposed || _webview == null) return;
+        Saucer.saucer_webview_reset_bounds(_webview);
     }
 
     private void ApplyWindowOptions()

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -73,14 +73,20 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
 
     /// <summary>Constructs a standalone window with no application host. Native operations are inert; used by
     /// tests that exercise the managed surface (events, accessor wiring) without a running event loop.</summary>
-    internal RynWindow(RynOptions options) : this(host: null, id: 0, options, options.ApplicationId) { }
+    internal RynWindow(RynOptions options) : this(host: null, id: 0, options, options.ApplicationId, isMain: true) { }
 
-    internal RynWindow(NativeAppHost? host, int id, RynOptions options, string stateKey)
+    // Whether this is the first (main) window. The main window is created during saucer's launch (OnReady) and
+    // loads its content before being shown; a secondary window is created after the loop is running and is shown
+    // before its content loads (see InitializeNative). Also gates the per-window PersistWindowState key.
+    private readonly bool _isMain;
+
+    internal RynWindow(NativeAppHost? host, int id, RynOptions options, string stateKey, bool isMain)
     {
         _host = host;
         Id = id;
         _options = options;
         _stateKey = stateKey;
+        _isMain = isMain;
         _cachedTitle = options.Title;
         _cachedWidth = options.Width;
         _cachedHeight = options.Height;
@@ -372,6 +378,40 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         }
 
         SubscribeWindowEvents();
+        // The main window is created during AppKit's launch display cycle and loads before it is shown. A
+        // secondary window is created after the loop is already running: show it FIRST, then load on the next
+        // tick so the window is on screen when its content navigates. NOTE: on macOS a WKWebView created after
+        // launch may still not composite its content — a WebKit limitation with windows opened off the launch
+        // cycle (see docs/multi-window.md). Showing-then-loading at least paints the page's themed background
+        // instead of a blank white view.
+        if (_isMain)
+        {
+            LoadContent();
+            Saucer.saucer_window_show(_window);
+            _host?.RunOnUi(RefitWebView);
+        }
+        else
+        {
+            Saucer.saucer_window_show(_window);
+            _host?.RunOnUi(() =>
+            {
+                if (_disposed || _webview == null) return;
+                RefitWebView();
+                LoadContent();
+            });
+        }
+    }
+
+    /// <summary>
+    /// Navigates the webview to the window's configured content: an external dev/remote URL, a local-server
+    /// origin, a content directory, or inline HTML (over the ryn:// app scheme where applicable). Split out of
+    /// <see cref="InitializeNative"/> so a secondary window can defer the load until after it is shown.
+    /// </summary>
+    private void LoadContent()
+    {
+        if (_rynWebView == null || _webview == null)
+            return;
+
         if (_options.Url != null)
         {
             var url = _options.Url;
@@ -418,26 +458,23 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         }
         else if (_options.ContentDirectory != null) { _rynWebView.SetContentDirectory(_options.ContentDirectory); _rynWebView.NavigateToAppScheme(); }
         else if (_options.Html != null) { _rynWebView.SetHtmlContent(_options.Html); _rynWebView.NavigateToAppScheme(); }
-        Saucer.saucer_window_show(_window);
-        // Re-fit the webview to its window on the NEXT loop tick. A webview created while the event loop is
-        // already running (a secondary window opened via OpenWindow) is added to a window whose content view is
-        // not yet at its final size, so the webview ends up at stale bounds and the window shows only its grey
-        // background. Re-fitting inline here is too early; deferring to the next tick — once the window has been
-        // realized and laid out — sets the correct bounds so the content fills the window. The main window is
-        // already laid out at startup, so this is a harmless no-op for it.
-        _host?.RunOnUi(RefitWebView);
     }
 
     /// <summary>
-    /// Re-fits the webview to fill its window's content view, posted to run after the window has been realized.
-    /// A webview created while the event loop is already running (a secondary window opened via OpenWindow) is
-    /// added before the window's content view is at its final size, so without this it can render at stale
-    /// bounds. The main window, laid out at startup, is unaffected.
+    /// Posted to run after a window has been realized: re-fits the webview to fill the window's content view,
+    /// makes a newly opened window key, and — on macOS — foregrounds the app. A webview created while the event
+    /// loop is already running (a secondary window opened via OpenWindow) is added before the content view is at
+    /// its final size, so without the re-fit it can render at stale bounds.
     /// </summary>
     private void RefitWebView()
     {
         if (_disposed || _webview == null) return;
         Saucer.saucer_webview_reset_bounds(_webview);
+        // A newly opened window should be key/front; for the main window this just reasserts the focus it holds.
+        if (_window != null) Saucer.saucer_window_focus(_window);
+        // Foreground the app: saucer orders the window front but does not activate the process, and a
+        // terminal-launched (non-bundled) binary does not activate itself, so it would otherwise stay inactive.
+        if (OperatingSystem.IsMacOS()) MacOsAppActivation.Activate();
     }
 
     private void ApplyWindowOptions()

--- a/src/Ryn.Core/RynWindowOptions.cs
+++ b/src/Ryn.Core/RynWindowOptions.cs
@@ -1,0 +1,89 @@
+namespace Ryn.Core;
+
+/// <summary>
+/// Per-window configuration passed to <see cref="RynApplication.OpenWindow(RynWindowOptions)"/> and the
+/// <c>window.open</c> IPC command. It is the per-window subset of <see cref="RynOptions"/> — the application
+/// already exists when a window is opened, so app-global settings (application id, deep-link schemes, embedded
+/// content, exception/logging policy) live only on <see cref="RynOptions"/> and are not repeated here.
+/// </summary>
+public sealed class RynWindowOptions
+{
+    /// <summary>The window title text.</summary>
+    public string Title { get; set; } = "Ryn Window";
+
+    /// <summary>Initial window width in pixels.</summary>
+    public int Width { get; set; } = 800;
+
+    /// <summary>Initial window height in pixels.</summary>
+    public int Height { get; set; } = 600;
+
+    /// <summary>Whether the window can be resized by the user.</summary>
+    public bool Resizable { get; set; } = true;
+
+    /// <summary>Controls the window title bar appearance.</summary>
+    public TitleBarStyle TitleBarStyle { get; set; } = TitleBarStyle.Native;
+
+    /// <summary>Whether the window background is transparent.</summary>
+    public bool Transparent { get; set; }
+
+    /// <summary>URL to navigate to on open. Mutually exclusive with <see cref="Html"/> and <see cref="ContentDirectory"/>.</summary>
+    public Uri? Url { get; set; }
+
+    /// <summary>Raw HTML string to load on open. Mutually exclusive with <see cref="Url"/> and <see cref="ContentDirectory"/>.</summary>
+    public string? Html { get; set; }
+
+    /// <summary>Directory of static web content to serve via the ryn:// scheme.</summary>
+    public string? ContentDirectory { get; set; }
+
+    /// <summary>Whether to serve content through a local HTTP server instead of the custom scheme.</summary>
+    public bool UseLocalServer { get; set; }
+
+    /// <summary>Fixed loopback port for the local content/IPC server. Falls back to a free port if taken.</summary>
+    public int LocalServerPort { get; set; } = 7421;
+
+    /// <summary>Path to the window icon file.</summary>
+    public string? IconPath { get; set; }
+
+    /// <summary>Whether browser developer tools are enabled for this window.</summary>
+    public bool DevTools { get; set; }
+
+    /// <summary>Whether to save and restore this window's position and size. Secondary windows persist under a
+    /// per-window key so they do not collide with the main window's state.</summary>
+    public bool PersistWindowState { get; set; }
+
+    /// <summary>Additional origins allowed to access IPC commands from this window.</summary>
+    public IList<string> AllowedOrigins { get; } = new List<string>();
+
+    /// <summary>Custom webview URL schemes to attach handlers for. Must already be registered (declared on the
+    /// main window's <see cref="RynOptions.CustomSchemes"/>) before the first webview was created.</summary>
+    public IList<string> CustomSchemes { get; } = new List<string>();
+
+    /// <summary>
+    /// Projects these per-window options onto a <see cref="RynOptions"/> instance for the window to consume.
+    /// App-global fields are left at their defaults — the application already exists, so they are unused for a
+    /// secondary window; the host supplies a per-window state key separately.
+    /// </summary>
+    internal RynOptions ToRynOptions()
+    {
+        var options = new RynOptions
+        {
+            Title = Title,
+            Width = Width,
+            Height = Height,
+            Resizable = Resizable,
+            TitleBarStyle = TitleBarStyle,
+            Transparent = Transparent,
+            Url = Url,
+            Html = Html,
+            ContentDirectory = ContentDirectory,
+            UseLocalServer = UseLocalServer,
+            LocalServerPort = LocalServerPort,
+            IconPath = IconPath,
+            DevTools = DevTools,
+            PersistWindowState = PersistWindowState,
+        };
+        foreach (var origin in AllowedOrigins) options.AllowedOrigins.Add(origin);
+        foreach (var scheme in CustomSchemes) options.CustomSchemes.Add(scheme);
+        return options;
+    }
+}

--- a/src/Ryn.Ipc/WindowCommands.cs
+++ b/src/Ryn.Ipc/WindowCommands.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Ryn.Core;
 
 namespace Ryn.Ipc;
@@ -6,32 +7,75 @@ namespace Ryn.Ipc;
 internal sealed class WindowCommands
 #pragma warning restore CA1812
 {
-    private readonly IRynWindow _window;
+    private readonly CurrentWindowAccessor _windows;
+    private readonly IRynWindowManager _manager;
 
-    public WindowCommands(IRynWindow window) => _window = window;
+    public WindowCommands(CurrentWindowAccessor windows, IRynWindowManager manager)
+    {
+        _windows = windows;
+        _manager = manager;
+    }
 
     [RynCommand("window.close")]
-    public void Close() => _window.Close();
+    public void Close() => _windows.Current.Close();
 
     [RynCommand("window.minimize")]
-    public void Minimize() => _window.Minimize();
+    public void Minimize() => _windows.Current.Minimize();
 
     [RynCommand("window.toggleMaximize")]
-    public void ToggleMaximize() => _window.ToggleMaximize();
+    public void ToggleMaximize() => _windows.Current.ToggleMaximize();
 
     [RynCommand("window.startDrag")]
-    public void StartDrag() => _window.StartDrag();
+    public void StartDrag() => _windows.Current.StartDrag();
 
     [RynCommand("window.startResize")]
-    public void StartResize(int edge) => _window.StartResize((WindowEdge)edge);
+    public void StartResize(int edge) => _windows.Current.StartResize((WindowEdge)edge);
 
     [RynCommand("window.setTitle")]
-    public void SetTitle(string title) => _window.Title = title;
+    public void SetTitle(string title) => _windows.Current.Title = title;
 
     [RynCommand("window.setSize")]
     public void SetSize(int width, int height)
     {
-        _window.Width = width;
-        _window.Height = height;
+        _windows.Current.Width = width;
+        _windows.Current.Height = height;
+    }
+
+    /// <summary>Returns the id of the window whose page invoked this command.</summary>
+    [RynCommand("window.current")]
+    public int Current() => _windows.Current.Id;
+
+    /// <summary>Returns the ids of all currently-open windows.</summary>
+    [RynCommand("window.list")]
+    public int[] List() => _manager.Windows.Select(w => w.Id).ToArray();
+
+    /// <summary>
+    /// Opens a new window and returns its id. Each field is an optional named argument so JS calls it naturally
+    /// as <c>window.__ryn.invoke('window.open', { title, width, height, html })</c>; omitted fields fall back to
+    /// the window defaults. Provide one of <paramref name="url"/>/<paramref name="html"/>/
+    /// <paramref name="contentDirectory"/> for the window's content.
+    /// </summary>
+    [RynCommand("window.open")]
+    public string Open(
+        string? title = null,
+        int? width = null,
+        int? height = null,
+        bool? resizable = null,
+        bool? devTools = null,
+        string? url = null,
+        string? html = null,
+        string? contentDirectory = null)
+    {
+        var options = new RynWindowOptions();
+        if (title is not null) options.Title = title;
+        if (width is { } w) options.Width = w;
+        if (height is { } h) options.Height = h;
+        if (resizable is { } r) options.Resizable = r;
+        if (devTools is { } d) options.DevTools = d;
+        if (url is not null && Uri.TryCreate(url, UriKind.Absolute, out var parsed)) options.Url = parsed;
+        if (html is not null) options.Html = html;
+        if (contentDirectory is not null) options.ContentDirectory = contentDirectory;
+
+        return _manager.OpenWindow(options).Id.ToString(CultureInfo.InvariantCulture);
     }
 }

--- a/tests/Ryn.Core.Tests/MultiWindowTests.cs
+++ b/tests/Ryn.Core.Tests/MultiWindowTests.cs
@@ -1,0 +1,194 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Ryn.Core.Internal;
+using Xunit;
+
+namespace Ryn.Core.Tests;
+
+/// <summary>
+/// Tests for the multi-window surface that can be exercised without starting the native event loop: the
+/// per-window options projection, the ambient "current window" routing seam (the mechanism behind window.*
+/// commands acting on the originating window), the window manager / accessor fallbacks, and the
+/// <see cref="RynApplication"/> public API before the loop is running. The full open-a-window IPC round trip
+/// is verified end-to-end by the AOT MultiWindow sample.
+/// </summary>
+public sealed class MultiWindowTests
+{
+    // ---- RynWindowOptions projection ----------------------------------------------------------------
+
+    [Fact]
+    public void RynWindowOptions_HasSensibleDefaults()
+    {
+        var options = new RynWindowOptions();
+
+        options.Title.Should().Be("Ryn Window");
+        options.Width.Should().Be(800);
+        options.Height.Should().Be(600);
+        options.Resizable.Should().BeTrue();
+        options.TitleBarStyle.Should().Be(TitleBarStyle.Native);
+        options.AllowedOrigins.Should().BeEmpty();
+        options.CustomSchemes.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToRynOptions_MapsEveryPerWindowField()
+    {
+        var options = new RynWindowOptions
+        {
+            Title = "Second",
+            Width = 321,
+            Height = 222,
+            Resizable = false,
+            TitleBarStyle = TitleBarStyle.Hidden,
+            Transparent = true,
+            Url = new Uri("https://example.test/app"),
+            UseLocalServer = true,
+            LocalServerPort = 9001,
+            IconPath = "/tmp/icon.png",
+            DevTools = true,
+            PersistWindowState = true,
+        };
+        options.AllowedOrigins.Add("https://allowed.test");
+        options.CustomSchemes.Add("custom");
+
+        var projected = options.ToRynOptions();
+
+        projected.Title.Should().Be("Second");
+        projected.Width.Should().Be(321);
+        projected.Height.Should().Be(222);
+        projected.Resizable.Should().BeFalse();
+        projected.TitleBarStyle.Should().Be(TitleBarStyle.Hidden);
+        projected.Transparent.Should().BeTrue();
+        projected.Url.Should().Be(new Uri("https://example.test/app"));
+        projected.UseLocalServer.Should().BeTrue();
+        projected.LocalServerPort.Should().Be(9001);
+        projected.IconPath.Should().Be("/tmp/icon.png");
+        projected.DevTools.Should().BeTrue();
+        projected.PersistWindowState.Should().BeTrue();
+        projected.AllowedOrigins.Should().ContainSingle().Which.Should().Be("https://allowed.test");
+        projected.CustomSchemes.Should().ContainSingle().Which.Should().Be("custom");
+    }
+
+    [Fact]
+    public void ToRynOptions_CarriesHtmlContent()
+    {
+        var projected = new RynWindowOptions { Html = "<h1>hi</h1>" }.ToRynOptions();
+
+        projected.Html.Should().Be("<h1>hi</h1>");
+        projected.Url.Should().BeNull();
+    }
+
+    // ---- Ambient current-window routing (the per-window dispatch seam) -------------------------------
+
+    [Fact]
+    public async Task CurrentWindow_Value_FlowsAcrossTheDispatchHop()
+    {
+        CurrentWindow.Value = null;
+        var window = Substitute.For<IRynWindow>();
+
+        // Mirror what RynWebView.ExecuteCommandAsync does: set the ambient, then hop to a worker thread.
+        CurrentWindow.Value = window;
+        var observed = await Task.Run(() => CurrentWindow.Value);
+
+        observed.Should().BeSameAs(window, "the ambient flows into the dispatched command via ExecutionContext");
+        CurrentWindow.Value = null;
+    }
+
+    [Fact]
+    public async Task CurrentWindow_ConcurrentDispatches_DoNotCollide()
+    {
+        CurrentWindow.Value = null;
+        var windowA = Substitute.For<IRynWindow>();
+        var windowB = Substitute.For<IRynWindow>();
+
+        // Two independent dispatches each stamp their own originating window; neither must see the other's.
+        var a = Task.Run(async () => { CurrentWindow.Value = windowA; await Task.Yield(); return CurrentWindow.Value; });
+        var b = Task.Run(async () => { CurrentWindow.Value = windowB; await Task.Yield(); return CurrentWindow.Value; });
+
+        (await a).Should().BeSameAs(windowA);
+        (await b).Should().BeSameAs(windowB);
+        CurrentWindow.Value.Should().BeNull("an inner dispatch's ambient must not leak back to the caller");
+    }
+
+    [Fact]
+    public void CurrentWindowAccessor_PrefersTheAmbientOriginatingWindow()
+    {
+        var accessor = new CurrentWindowAccessor(new NativeApplicationAccessor());
+        var window = Substitute.For<IRynWindow>();
+        window.Id.Returns(5);
+
+        CurrentWindow.Value = window;
+        try
+        {
+            accessor.Current.Should().BeSameAs(window);
+            accessor.Current.Id.Should().Be(5);
+        }
+        finally
+        {
+            CurrentWindow.Value = null;
+        }
+    }
+
+    [Fact]
+    public void CurrentWindowAccessor_ThrowsWhenNoAmbientAndNoRunningHost()
+    {
+        CurrentWindow.Value = null;
+        var accessor = new CurrentWindowAccessor(new NativeApplicationAccessor());
+
+        var act = () => accessor.Current;
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    // ---- RynWindowManager fallbacks (no running host) ------------------------------------------------
+
+    [Fact]
+    public void RynWindowManager_ListsNoWindows_BeforeTheLoopIsRunning()
+    {
+        var manager = new RynWindowManager(new NativeApplicationAccessor());
+
+        manager.Windows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RynWindowManager_OpenWindow_ThrowsBeforeTheLoopIsRunning()
+    {
+        var manager = new RynWindowManager(new NativeApplicationAccessor());
+
+        var act = () => manager.OpenWindow(new RynWindowOptions());
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    // ---- RynApplication public surface before RunAsync ----------------------------------------------
+
+    [Fact]
+    public async Task Application_WindowsCollection_IsEmptyBeforeRun()
+    {
+        await using var app = RynApplication.CreateBuilder().Build();
+
+        app.Windows.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Application_MainWindowAndOpenWindow_ThrowBeforeRun()
+    {
+        await using var app = RynApplication.CreateBuilder().Build();
+
+        var mainWindow = () => app.MainWindow;
+        var openWindow = () => app.OpenWindow(new RynWindowOptions());
+
+        mainWindow.Should().Throw<InvalidOperationException>();
+        openWindow.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Build_RegistersWindowManagerAndCurrentWindowAccessor()
+    {
+        await using var app = RynApplication.CreateBuilder().Build();
+
+        app.Services.GetService<IRynWindowManager>().Should().NotBeNull();
+        app.Services.GetService<CurrentWindowAccessor>().Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
Implements multi-window support: the application now manages multiple windows on one native event loop, each with its own webview and per-window IPC routing.

## What's included
- **Stage A** — extract `NativeAppHost` from `RynWindow` (owns the saucer application, run loop, UI-thread marshalling, pre-ready queue, and window registry).
- **Stages B+C** — `RynApplication.MainWindow`/`Windows`, `IRynWindow.Id`, and route `MainThreadDispatcher`/lifetime through the host.
- **Stage D** — `RynWindowOptions`, `OpenWindow`/`OpenWindowAsync`, `IRynWindowManager`, the `window.open`/`list`/`current`/`close`/… JS commands, per-window IPC origin routing, and the `samples/MultiWindow` demo.
- Secondary windows are shown before their content loads and the app foregrounds itself on launch.

## API
`RynApplication.MainWindow` / `Windows` / `OpenWindow` / `OpenWindowAsync`, the `IRynWindowManager` service, `RynWindowOptions`, and the `window.*` commands. The app now quits when the **last** window closes, not the main one.

## Backward compatibility
Single-window apps are unchanged: `app.Window`/`app.WebView` delegate to `MainWindow`, and `RynWindowAccessor.Window` still points at the main window.

## Known limitation
On macOS a window opened after launch may paint only its background, not its content — a WebKit/saucer first-paint limitation (the window, IPC, and events all work). Cause and status are documented in `docs/multi-window.md`.

## Verification
`dotnet build Ryn.slnx` 0 warnings · `dotnet test Ryn.slnx` 446 passing · NativeAOT publish clean.