### PR TITLE
fix: stop the templates package building an empty symbols package

### DIFF
--- a/templates/Ryn.Templates.csproj
+++ b/templates/Ryn.Templates.csproj
@@ -11,6 +11,8 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <PackageReadmeFile></PackageReadmeFile>
+    <!-- Content-only template package: no assembly, so no symbols package (avoids an empty .snupkg -> NU5017). -->
+    <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
The `v0.2.0` release failed at the Pack step with `NU5017: Cannot create a package that has no dependencies nor content` on `Ryn.Templates`.

**Cause:** `IncludeSymbols=true` is set globally in `Directory.Build.props` for every packable project. `Ryn.Templates` is a content-only template package (`IncludeBuildOutput=false`, `SuppressDependenciesWhenPacking=true`) — it has no assembly and no dependencies, so its symbols package (`.snupkg`) is empty and trips NU5017. The main `.nupkg` packs fine; only the empty symbols package fails. (The `Ryn` metapackage also has no build output but declares dependencies, so its snupkg isn't empty — which is why only Templates failed.)

This surfaced only at release time because `dotnet pack` runs only in `release.yml` (the build/test/AOT PR checks never pack).

**Fix:** `<IncludeSymbols>false</IncludeSymbols>` on `Ryn.Templates`.

Verified locally: `dotnet pack Ryn.slnx -c Release` now exits 0 with all 15 packages, and `Ryn.Templates.0.2.0.nupkg` contains the full `content/ryn-app/` template with the Ryn version substituted.