### PR TITLE
fix: drop the empty symbols package from the Ryn metapackage

### DIFF
--- a/src/Ryn/Ryn.csproj
+++ b/src/Ryn/Ryn.csproj
@@ -11,6 +11,10 @@
          the assemblies would have to embed its own copy of the generator, which then collides with
          Ryn.Ipc's copy when a plugin is also referenced — two generators, duplicate code.) -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <!-- No assembly of its own, so there are no symbols: skip the symbols package. An empty .snupkg packs
+         without error here (the metapackage has dependencies) but NuGet's symbol server rejects it on push
+         with "does not contain any symbol (.pdb) files". -->
+    <IncludeSymbols>false</IncludeSymbols>
     <IsAotCompatible>false</IsAotCompatible>
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
     <!-- NU5128: a metapackage legitimately has dependencies but no lib/ assemblies. -->


### PR DESCRIPTION
Follow-up to the templates snupkg fix. The v0.2.0 release got past Pack and Verify, then **Push to NuGet failed**: `Ryn.0.2.0.snupkg` was rejected with `400: The package does not contain any symbol (.pdb) files`.

The `Ryn` metapackage has `IncludeBuildOutput=false` (no assembly), so its symbols package is empty. Unlike `Ryn.Templates`, it has dependencies, so the empty snupkg packs without NU5017 — it only fails at the NuGet symbol-server push.

**Fix:** `<IncludeSymbols>false</IncludeSymbols>` on the metapackage (same as Templates).

Verified locally: `dotnet pack Ryn.slnx -c Release` exits 0, every produced `.snupkg` contains a `.pdb`, and `Ryn`/`Ryn.Templates` produce no snupkg.

Note: the failed run already published 6 of the 15 packages at 0.2.0; the release re-run uses `--skip-duplicate`, so it skips those and completes the rest.