### PR TITLE
chore: stop dependabot bumping the source generator's Roslyn floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,10 @@ updates:
       # FluentAssertions 8.x relicensed to the Xceed commercial license. Stay on the last
       # Apache-2.0 line (7.x); ignore all updates so it is never bumped past the pinned 7.2.0.
       - dependency-name: "FluentAssertions"
+      # Microsoft.CodeAnalysis.CSharp: the IPC source generator references it with no explicit version, so this
+      # is the floor that decides the minimum Roslyn (and thus SDK/IDE) able to load the generator. Keep it low
+      # for broad compatibility; do not bump. (Dependabot PRs #17/#19 were closed for exactly this reason.)
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp"
 
   # Frontend npm dependencies for the Vue sample (build-time dev tooling such as vite/esbuild).
   # These are not shipped in any published package, but keeping them current closes advisory


### PR DESCRIPTION
Adds `Microsoft.CodeAnalysis.CSharp` to the dependabot ignore list (nuget ecosystem). The IPC source generator references it with no explicit version, so its version in `Directory.Packages.props` is the floor that decides the minimum Roslyn — and therefore the minimum SDK/IDE — that can load the generator. We keep that floor low for broad compatibility. Dependabot PRs #17/#19 (which bumped it 4.13→4.14, grouped with benign Extensions/xunit patches) were closed for this reason; this prevents them recurring.