### PR TITLE
docs: use data-webview-drag for title-bar dragging (fixes drag desync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ docs/
   capabilities.md      Canonical ryn.json capability schema reference
   plugin-authoring.md  Guide for writing Ryn plugins
   vite-integration.md  Using Vite and TypeScript with Ryn
+  custom-title-bars.md Frameless title bars: data-webview-drag and window controls
+  multi-window.md      Opening and managing multiple windows
   accessibility-and-i18n.md  Current a11y / i18n stance
   ROADMAP.md           Planned work beyond the current alpha
 ```
@@ -347,6 +349,8 @@ docs/
 - [Capabilities Reference](docs/capabilities.md): the canonical `ryn.json` schema
 - [Plugin Authoring](docs/plugin-authoring.md): writing Ryn plugins with commands, options, DI, and events
 - [Vite Integration](docs/vite-integration.md): using Vite and TypeScript with Ryn
+- [Custom Title Bars](docs/custom-title-bars.md): frameless title bars, `data-webview-drag`, and window controls
+- [Multi-window](docs/multi-window.md): opening and managing multiple windows
 - [Accessibility & Internationalization](docs/accessibility-and-i18n.md): the current a11y / i18n stance
 - [Roadmap](docs/ROADMAP.md): planned capabilities beyond the current alpha
 - [Third-Party Notices](THIRD-PARTY-NOTICES.md): licenses for the native libraries Ryn redistributes

--- a/docs/custom-title-bars.md
+++ b/docs/custom-title-bars.md
@@ -1,0 +1,54 @@
+# Custom title bars and window dragging
+
+A frameless or overlay window (set `RynWindowOptions.TitleBarStyle`) lets your HTML own the title-bar area.
+To make a region of that HTML drag the window, resize it, or act as a window button, add a `data-webview-*`
+attribute to the element. The webview hit-tests these attributes **inside the `mousedown` event** and
+performs the native action immediately — no IPC round-trip, no lag.
+
+## Dragging
+
+```html
+<header data-webview-drag>
+  <span>My App</span>
+  <!-- interactive children must opt out, or clicking them would drag the window -->
+  <nav data-webview-ignore>
+    <button>One</button><button>Two</button>
+  </nav>
+</header>
+```
+
+- **`data-webview-drag`** — click-and-drag anywhere on the element moves the window.
+- **`data-webview-ignore`** — marks an interactive descendant (buttons, inputs, links) as *not* a drag
+  handle, so clicks reach it normally. Put it on anything clickable inside a drag region.
+
+## Window controls and resizing
+
+| Attribute | Effect |
+|---|---|
+| `data-webview-drag` | drag-move the window |
+| `data-webview-resize="<edge>"` | drag-resize from an edge/corner (`top`, `bottom`, `left`, `right`, `top-left`, `top-right`, `bottom-left`, `bottom-right`) |
+| `data-webview-close` | close the window on click |
+| `data-webview-minimize` | minimize on click |
+| `data-webview-maximize` | toggle maximize on click; `data-webview-maximize="double"` toggles only on a double-click |
+| `data-webview-ignore` | exclude an element from all of the above (keep it clickable) |
+
+These fire on a left-button `mousedown` and are handled natively, so they work on macOS (WKWebView),
+Windows (WebView2), and Linux (WebKitGTK) alike.
+
+## Why not `-webkit-app-region: drag`?
+
+`-webkit-app-region` is a Chromium/Electron CSS property — it is **not honored by WebKit**. It does nothing
+on macOS (WKWebView) or Linux (WebKitGTK), and works only incidentally on Windows (WebView2 is Chromium).
+Use `data-webview-drag` instead; it works on every backend.
+
+## Why not `window.startDrag` / `IRynWindow.StartDrag` for title bars?
+
+The `window.startDrag` IPC command (and `IRynWindow.StartDrag`) still exists as a programmatic escape
+hatch, but **don't use it to drag a title bar.** It routes through the IPC pipeline (XHR → loopback
+HTTP/scheme → UI-thread marshal), so the native drag begins only *after* the round-trip. On macOS that is
+visibly broken: the native `performWindowDragWithEvent:` reads the *current* event, which by the time the
+command runs is no longer the original mouse-down — so the window lags behind the cursor (drag desync).
+`data-webview-drag` starts the drag synchronously inside the mouse-down, so there is no lag.
+
+See `samples/VueApp` for a `data-webview-drag` title bar, and [multi-window.md](multi-window.md) for opening
+and managing multiple windows.

--- a/samples/VueApp/frontend/src/App.vue
+++ b/samples/VueApp/frontend/src/App.vue
@@ -12,11 +12,15 @@ const activeTab = ref<Tab>('System')
 
 <template>
   <div class="app">
-    <header>
+    <!-- data-webview-drag makes this strip a window-drag handle natively (saucer hit-tests it and starts the
+         OS drag inside the mousedown — zero IPC, no desync). It works on every backend, unlike the CSS
+         -webkit-app-region, which only Chromium/WebView2 honors. See docs/custom-title-bars.md. -->
+    <header data-webview-drag>
       <div class="logo">
         <span class="accent">Ryn</span> + Vue
       </div>
-      <nav>
+      <!-- data-webview-ignore keeps the buttons clickable instead of dragging the window. -->
+      <nav data-webview-ignore>
         <button
           v-for="tab in tabs"
           :key="tab"
@@ -62,7 +66,6 @@ header {
   height: 56px;
   background: #111118;
   border-bottom: 1px solid #1e1e2e;
-  -webkit-app-region: drag;
 }
 
 .logo {
@@ -78,7 +81,6 @@ header {
 nav {
   display: flex;
   gap: 4px;
-  -webkit-app-region: no-drag;
 }
 
 nav button {

--- a/src/Ryn.Core/IRynWindow.cs
+++ b/src/Ryn.Core/IRynWindow.cs
@@ -51,7 +51,12 @@ public interface IRynWindow
     public void ToggleMaximize();
     /// <summary>Moves the window's top-left corner to the given screen coordinates (in points).</summary>
     public void Move(int x, int y);
-    /// <summary>Initiates a window drag operation (for frameless windows).</summary>
+    /// <summary>
+    /// Initiates a window drag operation (for frameless windows). For dragging a title bar from HTML, prefer
+    /// the <c>data-webview-drag</c> attribute instead: it starts the OS drag synchronously inside the mousedown
+    /// with no IPC, whereas this command's round-trip makes the window lag the cursor on macOS. See
+    /// docs/custom-title-bars.md.
+    /// </summary>
     public void StartDrag();
     /// <summary>Initiates a window resize operation from the specified edge.</summary>
     public void StartResize(WindowEdge edge);

--- a/src/Ryn.Ipc/WindowCommands.cs
+++ b/src/Ryn.Ipc/WindowCommands.cs
@@ -25,6 +25,8 @@ internal sealed class WindowCommands
     [RynCommand("window.toggleMaximize")]
     public void ToggleMaximize() => _windows.Current.ToggleMaximize();
 
+    /// <summary>Programmatic window drag. For title bars, prefer the <c>data-webview-drag</c> attribute, which
+    /// drags natively inside the mousedown with no IPC lag (see docs/custom-title-bars.md).</summary>
     [RynCommand("window.startDrag")]
     public void StartDrag() => _windows.Current.StartDrag();
 


### PR DESCRIPTION
**Bug report:** dragging a custom title bar via `app.startDrag` desyncs — the window lags the cursor.

**Root cause:** `window.startDrag` routes through the IPC pipeline (XHR → loopback HTTP/scheme → UI-thread marshal), so the native drag starts only *after* the round-trip. On macOS, saucer's `start_drag` calls `performWindowDragWithEvent: NSApp.currentEvent`, which by then is no longer the original mouse-down — the OS captures against a stale event → desync. It's not about IPC speed (the HTTP read is already buffered); the native drag must fire *inside* the mousedown, which an IPC round-trip can't do.

**Fix:** use saucer's built-in `data-webview-drag` attribute. The webview hit-tests it inside the mousedown and starts the OS drag synchronously over the native bridge — zero IPC, no desync, all backends. It's already enabled in every Ryn webview (verified at runtime: `window.saucer.startDrag` is a function); it was just undocumented and unused.

- New `docs/custom-title-bars.md`: `data-webview-drag` + `-ignore`/`-resize`/`-close`/`-minimize`/`-maximize`.
- VueApp sample: header switched from `-webkit-app-region: drag` (dead on WebKit — did nothing on macOS) to `data-webview-drag`, nav marked `data-webview-ignore`. (Source only — the gitignored prebuilt `wwwroot` snapshot is left for a deliberate `npm run build` refresh, per its convention.)
- `window.startDrag` / `IRynWindow.StartDrag` kept as a programmatic escape hatch, with a caveat pointing to the attribute.

Note: the report's "byte-by-byte HTTP read" was already fixed (the reader buffers 8 KB chunks since the post-alpha.4 refactor); it isn't the cause and needs no change.