### PR TITLE
fix: serve embedded content from the local HTTP server (v0.3.1)

### DIFF
--- a/src/Ryn.Core/Internal/LocalWebServer.cs
+++ b/src/Ryn.Core/Internal/LocalWebServer.cs
@@ -24,6 +24,7 @@ internal sealed class LocalWebServer : IAsyncDisposable
     private const long MaxBodyBytes = 32L * 1024 * 1024;   // matches the previous body cap
 
     private readonly string? _contentDirectory;
+    private EmbeddedContentStore? _embeddedContent;
     private readonly string? _allowedCorsOrigin;
     private readonly int _preferredPort;
     private ILocalServerHost? _webView;
@@ -48,6 +49,10 @@ internal sealed class LocalWebServer : IAsyncDisposable
     }
 
     internal void SetWebView(ILocalServerHost webView) => _webView = webView;
+
+    /// <summary>Serve static requests from this in-memory embedded content first (bundled builds), falling back
+    /// to the on-disk content directory for anything not embedded (dev mode).</summary>
+    internal void SetEmbeddedContent(EmbeddedContentStore store) => _embeddedContent = store;
 
     internal Task StartAsync()
     {
@@ -482,44 +487,62 @@ internal sealed class LocalWebServer : IAsyncDisposable
 
     private async Task ServeStaticAsync(NetworkStream stream, HttpRequest request, bool keepAlive, CancellationToken ct)
     {
-        if (_contentDirectory is null)
-        {
-            await WriteTextAsync(stream, 404, "Not Found", "not found", keepAlive, ct).ConfigureAwait(false);
-            return;
-        }
-
-        var rawPath = request.Path;
-        var relative = Uri.UnescapeDataString(rawPath.TrimStart('/'));
+        var relative = Uri.UnescapeDataString(request.Path.TrimStart('/'));
         if (string.IsNullOrEmpty(relative))
             relative = "index.html";
-
-        var filePath = ResolveWithinContent(relative);
-
-        // SPA fallback: an unmatched route serves index.html (mirrors the previous MapFallback behavior).
-        if (filePath is null || !File.Exists(filePath))
-            filePath = ResolveWithinContent("index.html");
-
-        if (filePath is null || !File.Exists(filePath))
-        {
-            await WriteTextAsync(stream, 404, "Not Found", "not found", keepAlive, ct).ConfigureAwait(false);
-            return;
-        }
-
-        byte[] content;
-        try { content = await File.ReadAllBytesAsync(filePath, ct).ConfigureAwait(false); }
-        catch (IOException)
-        {
-            await WriteTextAsync(stream, 500, "Internal Server Error", "read error", keepAlive, ct).ConfigureAwait(false);
-            return;
-        }
 
         var headers = new List<(string, string)>
         {
             ("Cache-Control", "no-cache, no-store, must-revalidate"),
             ("X-Content-Type-Options", "nosniff"),
         };
-        var body = request.Method == "HEAD" ? [] : content;
-        await WriteAsync(stream, 200, "OK", GetMimeType(Path.GetExtension(filePath)), body, headers, keepAlive, ct).ConfigureAwait(false);
+
+        // Embedded content (bundled): serve from the in-memory map, SPA-falling back to index.html. This is what
+        // lets UseLocalServer compose with embedded content — a bundled single binary served over http://localhost
+        // (some scripts, e.g. Cloudflare Turnstile, reject the ryn:// origin).
+        if (_embeddedContent is not null)
+        {
+            var servedPath = relative;
+            var embeddedBytes = _embeddedContent.Get(relative);
+            if (embeddedBytes is null)
+            {
+                embeddedBytes = _embeddedContent.Get("index.html");
+                servedPath = "index.html";
+            }
+            if (embeddedBytes is not null)
+            {
+                var embeddedBody = request.Method == "HEAD" ? [] : embeddedBytes;
+                await WriteAsync(stream, 200, "OK", GetMimeType(Path.GetExtension(servedPath)), embeddedBody, headers, keepAlive, ct).ConfigureAwait(false);
+                return;
+            }
+        }
+
+        // On-disk content directory (dev mode, or an explicit ContentDirectory not covered by embedded content).
+        if (_contentDirectory is not null)
+        {
+            var filePath = ResolveWithinContent(relative);
+
+            // SPA fallback: an unmatched route serves index.html (mirrors the previous MapFallback behavior).
+            if (filePath is null || !File.Exists(filePath))
+                filePath = ResolveWithinContent("index.html");
+
+            if (filePath is not null && File.Exists(filePath))
+            {
+                byte[] content;
+                try { content = await File.ReadAllBytesAsync(filePath, ct).ConfigureAwait(false); }
+                catch (IOException)
+                {
+                    await WriteTextAsync(stream, 500, "Internal Server Error", "read error", keepAlive, ct).ConfigureAwait(false);
+                    return;
+                }
+
+                var body = request.Method == "HEAD" ? [] : content;
+                await WriteAsync(stream, 200, "OK", GetMimeType(Path.GetExtension(filePath)), body, headers, keepAlive, ct).ConfigureAwait(false);
+                return;
+            }
+        }
+
+        await WriteTextAsync(stream, 404, "Not Found", "not found", keepAlive, ct).ConfigureAwait(false);
     }
 
     /// <summary>Resolves a request-relative path under the content root, rejecting directory traversal.</summary>

--- a/src/Ryn.Core/RynApplicationBuilder.cs
+++ b/src/Ryn.Core/RynApplicationBuilder.cs
@@ -125,7 +125,10 @@ public sealed class RynApplicationBuilder
                 ConsoleLoggerProvider.Configure(logging, configuration.GetSection("Logging"));
         });
 
-        if (options.UseEmbeddedContent && options.ContentDirectory is null && options.EmbeddedContent is null)
+        // Load the embedded content into memory whenever embedding is on (even if a ContentDirectory is also set
+        // — in a bundled build the loose directory isn't shipped, and the scheme/local-server handlers serve
+        // embedded-first with the directory as a dev fallback). TryLoad returns null in dev (no embedded resource).
+        if (options.UseEmbeddedContent && options.EmbeddedContent is null)
         {
             options.EmbeddedContent = Internal.EmbeddedContentStore.TryLoad();
         }

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -444,9 +444,13 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
             Saucer.saucer_webview_set_url_str(_webview, urlStr.Pointer);
             urlStr.Dispose();
         }
-        else if (_options.UseLocalServer && _options.ContentDirectory != null)
+        else if (_options.UseLocalServer && (_options.ContentDirectory != null || _options.EmbeddedContent != null))
         {
+            // Local HTTP server: a real http://localhost origin (some scripts — e.g. Cloudflare Turnstile —
+            // reject the ryn:// origin). Composes both content sources: it serves embedded content from memory
+            // when bundled and falls back to the content directory on disk in dev.
             _localServer = new LocalWebServer(_options.ContentDirectory, _options.LocalServerPort);
+            if (_options.EmbeddedContent != null) _localServer.SetEmbeddedContent(_options.EmbeddedContent);
             _localServer.StartAsync().GetAwaiter().GetResult();
             _localServer.SetWebView(_rynWebView);
             var serverUrl = _localServer.Url;
@@ -456,8 +460,14 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
             Saucer.saucer_webview_set_url_str(_webview, urlStr.Pointer);
             urlStr.Dispose();
         }
-        else if (_options.ContentDirectory != null) { _rynWebView.SetContentDirectory(_options.ContentDirectory); _rynWebView.NavigateToAppScheme(); }
-        else if (_options.EmbeddedContent != null) { _rynWebView.SetEmbeddedContent(_options.EmbeddedContent); _rynWebView.NavigateToAppScheme(); }
+        else if (_options.ContentDirectory != null || _options.EmbeddedContent != null)
+        {
+            // ryn:// scheme. Set both sources when present; the handler serves embedded content from memory first
+            // and falls back to the on-disk content directory (dev mode).
+            if (_options.ContentDirectory != null) _rynWebView.SetContentDirectory(_options.ContentDirectory);
+            if (_options.EmbeddedContent != null) _rynWebView.SetEmbeddedContent(_options.EmbeddedContent);
+            _rynWebView.NavigateToAppScheme();
+        }
         else if (_options.Html != null) { _rynWebView.SetHtmlContent(_options.Html); _rynWebView.NavigateToAppScheme(); }
     }
 

--- a/tests/Ryn.Core.Tests/LocalWebServerEmbeddedTests.cs
+++ b/tests/Ryn.Core.Tests/LocalWebServerEmbeddedTests.cs
@@ -1,0 +1,86 @@
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using FluentAssertions;
+using Ryn.Core.Internal;
+using Xunit;
+
+namespace Ryn.Core.Tests;
+
+/// <summary>
+/// Verifies the local HTTP server composes with embedded content: a bundled build serves the in-memory byte[]
+/// map over http://localhost (so UseLocalServer works for scripts that reject the ryn:// origin, e.g. Cloudflare
+/// Turnstile), with no loose wwwroot on disk. The on-disk content directory remains a dev-mode fallback.
+/// </summary>
+public sealed class LocalWebServerEmbeddedTests : IAsyncLifetime
+{
+    private LocalWebServer _server = null!;
+    private HttpClient _client = null!;
+
+    private static EmbeddedContentStore MakeStore(params (string Path, string Content)[] files)
+    {
+        var ms = new MemoryStream();
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (path, content) in files)
+            {
+                using var entry = archive.CreateEntry(path).Open();
+                var bytes = Encoding.UTF8.GetBytes(content);
+                entry.Write(bytes, 0, bytes.Length);
+            }
+        }
+        ms.Position = 0;
+        return EmbeddedContentStore.LoadFrom(ms)!;
+    }
+
+    public async Task InitializeAsync()
+    {
+        // No content directory on disk — the server must serve purely from the in-memory embedded store.
+        _server = new LocalWebServer(contentDirectory: null, preferredPort: 28760);
+        _server.SetWebView(new FakeHost());
+        _server.SetEmbeddedContent(MakeStore(
+            ("index.html", "<html>EMBEDDED</html>"),
+            ("assets/app.js", "console.log('embedded')")));
+        await _server.StartAsync();
+        _client = new HttpClient { BaseAddress = new Uri(_server.Url) };
+    }
+
+    public async Task DisposeAsync()
+    {
+        _client.Dispose();
+        await _server.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task ServesEmbeddedIndexAtRoot()
+    {
+        var resp = await _client.GetAsync("/");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("EMBEDDED");
+    }
+
+    [Fact]
+    public async Task ServesEmbeddedAssetWithMimeType()
+    {
+        var resp = await _client.GetAsync("/assets/app.js");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        resp.Content.Headers.ContentType!.MediaType.Should().Be("application/javascript");
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("embedded");
+    }
+
+    [Fact]
+    public async Task UnknownRoute_FallsBackToEmbeddedIndex_ForSpa()
+    {
+        var resp = await _client.GetAsync("/some/client/route");
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await resp.Content.ReadAsStringAsync()).Should().Contain("EMBEDDED");
+    }
+
+    private sealed class FakeHost : ILocalServerHost
+    {
+        public string IpcToken { get; } = Guid.NewGuid().ToString("N");
+        public Task<(bool Ok, string Data)> DispatchCommandFromServerAsync(string command, string body) => Task.FromResult((true, "null"));
+        public void HandleEvalFromServer(long evalId, int ok, string body) { }
+    }
+}


### PR DESCRIPTION
Completes the v0.3.0 in-memory embedded content: it worked with the ryn:// scheme handler but **not** with `UseLocalServer`, which still read `ContentDirectory` from disk — so a bundled build (no loose `wwwroot`) served over `http://localhost` just 404'd. That made `UseEmbeddedContent` and `UseLocalServer` mutually exclusive.

Why it matters: some scripts require an `http://` origin and reject `ryn://` — e.g. Cloudflare Turnstile (silent CAPTCHA) returns error 110200 on the `ryn://app` origin, and silent mode needs the browser DOM, so it can't move server-side. Such apps are stuck on `UseLocalServer` and previously couldn't ship a single binary.

**Fix:** `LocalWebServer` now serves from the same in-memory `EmbeddedContentStore` the scheme handler uses — **embedded-first, with the on-disk content directory as a dev fallback** (SPA fallback to `index.html` preserved). The builder loads the store whenever `UseEmbeddedContent` is on (even with a `ContentDirectory` set), and `LoadContent` sets both sources so embedded wins with disk as the dev fallback. No new API — `UseLocalServer` + `UseEmbeddedContent` now compose.

Result: `UseLocalServer` + `ryn bundle` = a single binary served over `http://localhost`, no loose files; dev mode still serves from disk with hot reload.

## Verification
`dotnet build Ryn.slnx` 0 warnings · `dotnet test Ryn.slnx` all green. New `LocalWebServerEmbeddedTests` serve root index, an asset (correct MIME), and an SPA-fallback route purely from the in-memory store with no content directory on disk.