### PR TITLE
feat: expose webview hardware acceleration and browser flags

### DIFF
--- a/src/Ryn.Core/RynApplicationBuilder.cs
+++ b/src/Ryn.Core/RynApplicationBuilder.cs
@@ -236,6 +236,9 @@ public sealed class RynApplicationBuilder
         if (section[nameof(RynOptions.DevTools)] is { } devTools && bool.TryParse(devTools, out var d))
             options.DevTools = d;
 
+        if (section[nameof(RynOptions.HardwareAcceleration)] is { } hwAccel && bool.TryParse(hwAccel, out var hw))
+            options.HardwareAcceleration = hw;
+
         // Url intentionally excluded — Uri binding needs TypeConverter reflection, keep code-only
     }
 
@@ -256,6 +259,7 @@ public sealed class RynApplicationBuilder
         CopyIfSet(target, source, nameof(RynOptions.Resizable), static (t, s) => t.Resizable = s.Resizable);
         CopyIfSet(target, source, nameof(RynOptions.TitleBarStyle), static (t, s) => t.TitleBarStyle = s.TitleBarStyle);
         CopyIfSet(target, source, nameof(RynOptions.Transparent), static (t, s) => t.Transparent = s.Transparent);
+        CopyIfSet(target, source, nameof(RynOptions.HardwareAcceleration), static (t, s) => t.HardwareAcceleration = s.HardwareAcceleration);
         CopyIfSet(target, source, nameof(RynOptions.Url), static (t, s) => t.Url = s.Url);
         CopyIfSet(target, source, nameof(RynOptions.Html), static (t, s) => t.Html = s.Html);
         CopyIfSet(target, source, nameof(RynOptions.ContentDirectory), static (t, s) => t.ContentDirectory = s.ContentDirectory);
@@ -287,6 +291,12 @@ public sealed class RynApplicationBuilder
         {
             target.CustomSchemes.Clear();
             foreach (var scheme in source.CustomSchemes) target.CustomSchemes.Add(scheme);
+        }
+
+        if (source.BrowserFlags.Count > 0)
+        {
+            target.BrowserFlags.Clear();
+            foreach (var flag in source.BrowserFlags) target.BrowserFlags.Add(flag);
         }
     }
 

--- a/src/Ryn.Core/RynOptions.cs
+++ b/src/Ryn.Core/RynOptions.cs
@@ -25,6 +25,7 @@ public sealed class RynOptions
     private bool _resizable = true;
     private TitleBarStyle _titleBarStyle = TitleBarStyle.Native;
     private bool _transparent;
+    private bool _hardwareAcceleration = true;
     private Uri? _url;
     private string? _html;
     private string? _contentDirectory;
@@ -71,6 +72,15 @@ public sealed class RynOptions
 
     /// <summary>Whether the window background is transparent.</summary>
     public bool Transparent { get => _transparent; set => Set(ref _transparent, value); }
+
+    /// <summary>
+    /// Whether the webview renders with GPU hardware acceleration. Default true (the engine's own default).
+    /// Set false to force software rendering — a compatibility escape hatch for flaky GPU drivers (notably some
+    /// Linux/WebKitGTK setups) or virtualized/headless environments. Leaving it on is what you want for canvas,
+    /// WebGL and WebGPU workloads; turning it off makes those much slower. Applied once, before the webview is
+    /// created, so it cannot change for a live window.
+    /// </summary>
+    public bool HardwareAcceleration { get => _hardwareAcceleration; set => Set(ref _hardwareAcceleration, value); }
 
     /// <summary>URL to navigate to on startup. Mutually exclusive with <see cref="Html"/> and <see cref="ContentDirectory"/>.</summary>
     public Uri? Url { get => _url; set => Set(ref _url, value); }
@@ -146,6 +156,22 @@ public sealed class RynOptions
     /// the engine before the webview exists.
     /// </summary>
     public IList<string> CustomSchemes { get; } = new List<string>();
+
+    /// <summary>
+    /// Engine-specific flags passed to the underlying webview before it is created — the lever for opting into
+    /// experimental rendering features. The syntax is <b>not portable</b> across platforms, because each OS uses
+    /// a different engine:
+    /// <list type="bullet">
+    /// <item>Windows (WebView2/Chromium): Chromium command-line switches, e.g. <c>--enable-unsafe-webgpu</c>,
+    /// <c>--ignore-gpu-blocklist</c>, <c>--enable-features=Vulkan</c>.</item>
+    /// <item>Linux (WebKitGTK): WebKit feature/setting flags.</item>
+    /// <item>macOS (WKWebView): <c>key=value</c> pairs applied to <c>WKWebViewConfiguration</c> (value parsed as
+    /// JSON); a flag with no <c>=</c> is ignored.</item>
+    /// </list>
+    /// Guard platform-specific flags behind an OS check so a Chromium switch isn't handed to WebKit. Empty by
+    /// default. Applied once, before webview creation.
+    /// </summary>
+    public IList<string> BrowserFlags { get; } = new List<string>();
 
     /// <summary>True when <paramref name="propertyName"/> was explicitly assigned on this instance.</summary>
     internal bool IsSet(string propertyName) => _setProperties.Contains(propertyName);

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -305,6 +305,20 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
                 _host.RegisterScheme(customScheme);
         }
         var webviewOpts = Saucer.saucer_webview_options_new(_window);
+        // GPU acceleration and engine flags must be set on the options before the webview is created — they
+        // configure how the render process is spun up, so there is no after-the-fact equivalent on a live webview.
+        Saucer.saucer_webview_options_set_hardware_acceleration(webviewOpts, _options.HardwareAcceleration ? (byte)1 : (byte)0);
+        if (_options.BrowserFlags.Count > 0)
+        {
+            Span<byte> flagBuf = stackalloc byte[256];
+            foreach (var flag in _options.BrowserFlags)
+            {
+                if (string.IsNullOrEmpty(flag)) continue;
+                var flagStr = Utf8String.Create(flag, flagBuf);
+                Saucer.saucer_webview_options_append_browser_flag(webviewOpts, flagStr.Pointer);
+                flagStr.Dispose();
+            }
+        }
         _webview = Saucer.saucer_webview_new(webviewOpts, &error);
         Saucer.saucer_webview_options_free(webviewOpts);
         if (_webview == null) throw new InvalidOperationException($"Failed to create saucer webview (error code: {error})");

--- a/src/Ryn.Core/RynWindowOptions.cs
+++ b/src/Ryn.Core/RynWindowOptions.cs
@@ -38,6 +38,16 @@ public sealed class RynWindowOptions
     /// <summary>Whether the window background is transparent.</summary>
     public bool Transparent { get; set; }
 
+    /// <summary>Whether the webview renders with GPU hardware acceleration (default true). Set false only as a
+    /// compatibility escape hatch for flaky GPU drivers or headless/virtualized environments — it makes canvas,
+    /// WebGL and WebGPU much slower. Applied once, before the webview is created.</summary>
+    public bool HardwareAcceleration { get; set; } = true;
+
+    /// <summary>Engine-specific webview flags applied before creation — the lever for experimental rendering
+    /// features (e.g. <c>--enable-unsafe-webgpu</c> on Windows/Chromium). Syntax is not portable across
+    /// platforms; see <see cref="RynOptions.BrowserFlags"/> for the per-engine format.</summary>
+    public IList<string> BrowserFlags { get; } = new List<string>();
+
     /// <summary>URL to navigate to on open. Mutually exclusive with <see cref="Html"/> and <see cref="ContentDirectory"/>.</summary>
     public Uri? Url { get; set; }
 
@@ -89,6 +99,7 @@ public sealed class RynWindowOptions
             Resizable = Resizable,
             TitleBarStyle = TitleBarStyle,
             Transparent = Transparent,
+            HardwareAcceleration = HardwareAcceleration,
             Url = Url,
             Html = Html,
             ContentDirectory = ContentDirectory,
@@ -100,6 +111,7 @@ public sealed class RynWindowOptions
         };
         foreach (var origin in AllowedOrigins) options.AllowedOrigins.Add(origin);
         foreach (var scheme in CustomSchemes) options.CustomSchemes.Add(scheme);
+        foreach (var flag in BrowserFlags) options.BrowserFlags.Add(flag);
         return options;
     }
 }

--- a/tests/Ryn.Core.Tests/MultiWindowTests.cs
+++ b/tests/Ryn.Core.Tests/MultiWindowTests.cs
@@ -52,9 +52,11 @@ public sealed class MultiWindowTests
             IconPath = "/tmp/icon.png",
             DevTools = true,
             PersistWindowState = true,
+            HardwareAcceleration = false,
         };
         options.AllowedOrigins.Add("https://allowed.test");
         options.CustomSchemes.Add("custom");
+        options.BrowserFlags.Add("--enable-unsafe-webgpu");
 
         var projected = options.ToRynOptions();
 
@@ -74,8 +76,10 @@ public sealed class MultiWindowTests
         projected.IconPath.Should().Be("/tmp/icon.png");
         projected.DevTools.Should().BeTrue();
         projected.PersistWindowState.Should().BeTrue();
+        projected.HardwareAcceleration.Should().BeFalse();
         projected.AllowedOrigins.Should().ContainSingle().Which.Should().Be("https://allowed.test");
         projected.CustomSchemes.Should().ContainSingle().Which.Should().Be("custom");
+        projected.BrowserFlags.Should().ContainSingle().Which.Should().Be("--enable-unsafe-webgpu");
     }
 
     [Fact]


### PR DESCRIPTION
Adds two webview-creation knobs to `RynOptions` / `RynWindowOptions`, both applied once before the webview exists (no live equivalent):

- **`HardwareAcceleration`** (bool, default `true`) → `saucer_webview_options_set_hardware_acceleration`. A compatibility escape hatch — leave it on for canvas/WebGL/WebGPU; set false only for flaky GPU drivers or headless/virtualized environments.
- **`BrowserFlags`** (`IList<string>`) → `saucer_webview_options_append_browser_flag`. The lever for experimental rendering features (e.g. `--enable-unsafe-webgpu` on Windows/Chromium). Syntax is **not portable** across platforms — documented per-engine on the property.

Both flow through configuration binding, the programmatic-override merge, and the `ToRynOptions()` projection, so secondary windows inherit them.

Deliberately did **not** expose saucer's `set_attributes` knob: despite the name it toggles the `data-webview-*` titlebar script injection (load-bearing for `data-webview-drag`), not GPU.

Tests: extended `MultiWindowTests.ToRynOptions_MapsEveryPerWindowField` to assert both new fields project. Full Core suite green (138 passed, 0 warnings).