### PR TITLE
fix: make ryn bundle embed wwwroot and harden Windows AOT

### DIFF
--- a/src/Ryn.Cli/Commands/BuildCommand.cs
+++ b/src/Ryn.Cli/Commands/BuildCommand.cs
@@ -52,13 +52,15 @@ internal static class BuildCommand
         if (embedContent)
             arguments += " -p:RynEmbedContent=true";
 
-        var process = Process.Start(new ProcessStartInfo
+        var psi = new ProcessStartInfo
         {
             FileName = dotnet,
             Arguments = arguments,
             WorkingDirectory = projectDir,
             UseShellExecute = false,
-        });
+        };
+        NativeAotToolchain.Configure(psi, useAot);
+        var process = Process.Start(psi);
 
         process?.WaitForExit();
 

--- a/src/Ryn.Cli/Commands/BundleCommand.cs
+++ b/src/Ryn.Cli/Commands/BundleCommand.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO.Compression;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text.Json;
@@ -32,27 +33,57 @@ internal static class BundleCommand
         if (dotnet is null)
             return 1;
 
+        var useAot = args.Contains("--aot");
+        var embedContent = args.Contains("--embed");
+        var zipPath = Path.Combine(projectDir, "ryn_embedded_content.zip");
+
+        // Stage the embedded-content zip next to the .csproj so Ryn.Core.targets bakes it into the
+        // assembly as a manifest resource (and stamps the UseEmbeddedContent metadata). Without this the
+        // -p:RynEmbedContent=true flag is a no-op: the published binary has no embedded resource, the app
+        // falls back to disk, finds no wwwroot, and shows "not found".
+        if (embedContent)
+        {
+            var wwwroot = Path.Combine(projectDir, "wwwroot");
+            if (!Directory.Exists(wwwroot))
+            {
+                Console.Error.WriteLine("  --embed specified but no wwwroot/ directory found.");
+                return 1;
+            }
+            if (File.Exists(zipPath)) File.Delete(zipPath);
+            ZipFile.CreateFromDirectory(wwwroot, zipPath);
+            Console.WriteLine("  Embedded wwwroot content into zip");
+        }
+
         // The exact same publish arguments are reused both for the build and for the deterministic
         // PublishDir query below, so the directory we bundle from is the one this publish produced.
         var publishArgs = BuildPublishArgs(args);
 
         Console.WriteLine($"Building {projectName} for release...");
-        var buildProcess = Process.Start(new ProcessStartInfo
+        var buildPsi = new ProcessStartInfo
         {
             FileName = dotnet,
             Arguments = publishArgs,
             WorkingDirectory = projectDir,
             UseShellExecute = false,
-        });
+        };
+        NativeAotToolchain.Configure(buildPsi, useAot);
+        var buildProcess = Process.Start(buildPsi);
         buildProcess?.WaitForExit();
 
         if (buildProcess?.ExitCode != 0)
         {
+            DeleteStagedZip(embedContent, zipPath);
             Console.Error.WriteLine("  Build failed.");
             return 1;
         }
 
         var publishDir = ResolvePublishDir(dotnet, projectDir, publishArgs);
+
+        // Only now remove the staged zip. ResolvePublishDir re-runs publish with the same args
+        // (--getProperty:PublishDir), which re-evaluates the project; if the zip were already gone that
+        // evaluation would rebuild App.dll without the embedded resource, silently undoing the embed. The
+        // zip is a transient build input baked into the assembly by this point, so it is never committed.
+        DeleteStagedZip(embedContent, zipPath);
         if (publishDir is null)
         {
             Console.Error.WriteLine("  Could not locate the publish output directory.");
@@ -64,10 +95,10 @@ internal static class BundleCommand
             return CreateMacAppBundle(projectDir, projectName, publishDir, args);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            return CreateWindowsBundle(projectDir, projectName, publishDir, args);
+            return CreateWindowsBundle(projectDir, projectName, publishDir, args, embedContent);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            return CreateLinuxBundle(projectDir, projectName, publishDir, args);
+            return CreateLinuxBundle(projectDir, projectName, publishDir, args, embedContent);
 
         Console.WriteLine();
         Console.WriteLine($"  Bundle ready: {publishDir}");
@@ -387,6 +418,20 @@ internal static class BundleCommand
         return schemes;
     }
 
+    /// <summary>
+    /// Removes the transient <c>ryn_embedded_content.zip</c> staged next to the project for an embed build.
+    /// Best-effort: a leftover zip is harmless, so IO failures are swallowed. No-op when not embedding.
+    /// </summary>
+    private static void DeleteStagedZip(bool embedContent, string zipPath)
+    {
+        if (!embedContent || !File.Exists(zipPath))
+            return;
+
+        try { File.Delete(zipPath); }
+        catch (IOException) { /* best-effort cleanup; a leftover zip is harmless */ }
+        catch (UnauthorizedAccessException) { /* best-effort cleanup */ }
+    }
+
     private static string XmlEscape(string value) => SecurityElement.Escape(value) ?? value;
 
     private static string? GetArgValue(ReadOnlySpan<string> args, string flag)
@@ -529,7 +574,7 @@ internal static class BundleCommand
         catch (UnauthorizedAccessException) { return null; }
     }
 
-    private static int CreateWindowsBundle(string projectDir, string projectName, string publishDir, ReadOnlySpan<string> args)
+    private static int CreateWindowsBundle(string projectDir, string projectName, string publishDir, ReadOnlySpan<string> args, bool embedContent)
     {
         var bundleDir = Path.Combine(projectDir, "bin", "bundle", projectName);
 
@@ -580,9 +625,10 @@ internal static class BundleCommand
             File.Copy(file, destPath, overwrite: true);
         }
 
-        // Copy wwwroot if present
+        // Copy wwwroot if present. Skipped when embedding: the content is baked into the binary and served
+        // from memory, so a loose wwwroot beside the .exe would be redundant duplicate files.
         var wwwrootDir = Path.Combine(projectDir, "wwwroot");
-        if (Directory.Exists(wwwrootDir))
+        if (!embedContent && Directory.Exists(wwwrootDir))
         {
             var destWwwroot = Path.Combine(bundleDir, "wwwroot");
             foreach (var file in Directory.GetFiles(wwwrootDir, "*", SearchOption.AllDirectories))
@@ -791,7 +837,7 @@ internal static class BundleCommand
         return new Guid(guidBytes).ToString("D");
     }
 
-    private static int CreateLinuxBundle(string projectDir, string projectName, string publishDir, ReadOnlySpan<string> args)
+    private static int CreateLinuxBundle(string projectDir, string projectName, string publishDir, ReadOnlySpan<string> args, bool embedContent)
     {
         var bundleDir = Path.Combine(projectDir, "bin", "bundle", projectName + ".AppDir");
 
@@ -854,9 +900,10 @@ internal static class BundleCommand
             File.Copy(file, destPath, overwrite: true);
         }
 
-        // Copy wwwroot if present
+        // Copy wwwroot if present. Skipped when embedding: the content lives in the binary and is served
+        // from memory, so a loose wwwroot in usr/bin would be redundant duplicate files.
         var wwwrootDir = Path.Combine(projectDir, "wwwroot");
-        if (Directory.Exists(wwwrootDir))
+        if (!embedContent && Directory.Exists(wwwrootDir))
         {
             var destWwwroot = Path.Combine(usrBin, "wwwroot");
             foreach (var file in Directory.GetFiles(wwwrootDir, "*", SearchOption.AllDirectories))
@@ -1068,6 +1115,10 @@ internal static class BundleCommand
             else if (args[i] == "--self-contained")
             {
                 sb.Append(" --self-contained");
+            }
+            else if (args[i] == "--embed")
+            {
+                sb.Append(" -p:RynEmbedContent=true");
             }
         }
 

--- a/src/Ryn.Cli/NativeAotToolchain.cs
+++ b/src/Ryn.Cli/NativeAotToolchain.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Ryn.Cli;
+
+/// <summary>
+/// Helpers for making Native AOT publishes succeed on Windows. AOT links with the MSVC toolchain, which the
+/// .NET SDK locates by shelling out to <c>vswhere.exe</c> in the Visual Studio Installer directory. On
+/// Build Tools installs that directory is frequently not on <c>PATH</c>, so the link step fails and
+/// <c>dotnet publish</c> degrades to a framework-dependent output (hundreds of <c>System.*.dll</c>) instead
+/// of a single native binary — usually without an obvious error. We prepend the standard installer directory
+/// to the spawned publish process's <c>PATH</c> when it exists, and warn clearly when no <c>vswhere</c> can be
+/// found at all so the failure is diagnosable rather than silent.
+/// </summary>
+internal static class NativeAotToolchain
+{
+    /// <summary>
+    /// When publishing with AOT on Windows, ensures <c>vswhere.exe</c> is reachable from the given publish
+    /// process by prepending the VS Installer directory to its <c>PATH</c>. No-op on non-Windows, or when AOT
+    /// was not requested, or when <c>vswhere</c> is already on <c>PATH</c>.
+    /// </summary>
+    internal static void Configure(ProcessStartInfo psi, bool useAot)
+    {
+        ArgumentNullException.ThrowIfNull(psi);
+
+        if (!useAot || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        if (IsOnPath("vswhere.exe"))
+            return;
+
+        var installerDir = VsInstallerDirectory();
+        if (installerDir is not null)
+        {
+            var current = psi.Environment.TryGetValue("PATH", out var existing) && !string.IsNullOrEmpty(existing)
+                ? existing
+                : Environment.GetEnvironmentVariable("PATH") ?? "";
+            psi.Environment["PATH"] = installerDir + Path.PathSeparator + current;
+            Console.WriteLine($"  NativeAOT: added the Visual Studio Installer to PATH ({installerDir})");
+        }
+        else
+        {
+            Console.Error.WriteLine("  Warning: NativeAOT was requested but 'vswhere.exe' is not on PATH or in the");
+            Console.Error.WriteLine("  Visual Studio Installer directory. AOT needs the \"Desktop development with C++\"");
+            Console.Error.WriteLine("  workload (Visual Studio or Build Tools); without it the link step fails and the");
+            Console.Error.WriteLine("  publish falls back to a framework-dependent build. Install that workload, or run");
+            Console.Error.WriteLine("  from a Developer Command Prompt, then bundle again.");
+        }
+    }
+
+    /// <summary>
+    /// The directory that holds <c>vswhere.exe</c> for every VS edition including Build Tools, or null if it
+    /// does not exist on this machine. vswhere ships at a fixed path under the x86 Program Files.
+    /// </summary>
+    private static string? VsInstallerDirectory()
+    {
+        var programFilesX86 = Environment.GetEnvironmentVariable("ProgramFiles(x86)")
+            ?? Environment.GetEnvironmentVariable("ProgramFiles");
+        if (string.IsNullOrEmpty(programFilesX86))
+            return null;
+
+        var dir = Path.Combine(programFilesX86, "Microsoft Visual Studio", "Installer");
+        return File.Exists(Path.Combine(dir, "vswhere.exe")) ? dir : null;
+    }
+
+    /// <summary>True if <paramref name="exe"/> exists in any directory on the current <c>PATH</c>.</summary>
+    private static bool IsOnPath(string exe)
+    {
+        var pathEnv = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathEnv))
+            return false;
+
+        foreach (var dir in pathEnv.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            try
+            {
+                if (File.Exists(Path.Combine(dir, exe)))
+                    return true;
+            }
+            catch (ArgumentException)
+            {
+                // A PATH entry with invalid path characters — skip it.
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Ryn.Cli/Program.cs
+++ b/src/Ryn.Cli/Program.cs
@@ -254,7 +254,7 @@ internal static class Program
 
         internal static readonly CommandSpec Bundle = new(
             "bundle",
-            BooleanFlags: ["--aot", "--self-contained", "--notarize", "--dmg"],
+            BooleanFlags: ["--aot", "--self-contained", "--embed", "--notarize", "--dmg"],
             ValueFlags: ["--project", "-p", "--rid", "--version", "--icon", "--sign",
                 "--entitlements", "--notary-profile", "--deep-link-scheme"],
             Usage: """
@@ -277,6 +277,8 @@ internal static class Program
                   --deep-link-scheme <name>  Register a custom URL scheme (repeatable)
                   --aot                      Publish with NativeAOT
                   --self-contained           Publish self-contained
+                  --embed                    Embed wwwroot/ into the binary (served from memory;
+                                             no loose wwwroot is staged in the bundle)
                   -h, --help                 Show this help
                 """);
 

--- a/src/Ryn.Core/build/Ryn.Core.targets
+++ b/src/Ryn.Core/build/Ryn.Core.targets
@@ -22,4 +22,21 @@
   <ItemGroup Condition="'$(RynEmbedContent)' == 'true' AND Exists('ryn_embedded_content.zip')">
     <AssemblyMetadata Include="Ryn.UseEmbeddedContent" Value="true" />
   </ItemGroup>
+
+  <!--
+    When content is embedded, the loose wwwroot copy in the build/publish output is redundant —
+    EmbeddedContentStore serves it from memory — and ships duplicate files next to the binary (and,
+    for `ryn bundle`, inside the .app/AppDir/MSI staging). Drop the wwwroot Content/None items before
+    AssignTargetPaths gives them output paths, so neither `dotnet build` nor `dotnet publish` copies
+    them. Gated on RynEmbedContent only (no zip needed), so a normal Debug build keeps wwwroot on disk
+    for hot reload and only an embed-flagged `ryn build` / `ryn bundle` strips it.
+  -->
+  <Target Name="RynStripLooseContentWhenEmbedded"
+          Condition="'$(RynEmbedContent)' == 'true'"
+          BeforeTargets="AssignTargetPaths">
+    <ItemGroup>
+      <Content Remove="wwwroot/**" />
+      <None Remove="wwwroot/**" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/tests/Ryn.Cli.Tests/CliCommandTests.cs
+++ b/tests/Ryn.Cli.Tests/CliCommandTests.cs
@@ -104,6 +104,87 @@ public sealed class CliCommandTests
     }
 
     [Fact]
+    public async Task Bundle_Help_ListsEmbedOption()
+    {
+        var result = await RunCliAsync("bundle", null, "--help");
+        result.ExitCode.Should().Be(0);
+        result.Stdout.Should().Contain("--embed", because: "bundle must document the embed option like build does");
+    }
+
+    [Fact]
+    public async Task Bundle_Embed_NoWwwroot_ReturnsErrorWithoutPublishing()
+    {
+        // --embed must be a recognized flag (not exit 2 "Unknown option") and must fail fast with a clear
+        // message when there's nothing to embed — before any dotnet publish is attempted.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ryn-embed-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        WriteMinimalCsproj(Path.Combine(tempDir, "App.csproj"));
+        try
+        {
+            var result = await RunCliAsync("bundle", tempDir, "--embed");
+
+            result.ExitCode.Should().Be(1, because: $"--embed with no wwwroot is an error. stderr: {result.Stderr}");
+            result.Stderr.Should().Contain("wwwroot", because: "the error must name the missing wwwroot directory");
+            result.Stderr.Should().NotContain("Unknown option", because: "--embed must be a recognized bundle flag");
+            result.Stdout.Should().NotContain("Building", because: "the missing-wwwroot check must run before publish");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Bundle_Embed_BakesContentIntoBinaryAndStripsLooseWwwroot()
+    {
+        // Full chain: `ryn bundle --embed` must stage the zip, pass -p:RynEmbedContent=true, let the targets
+        // bake it into the assembly as a manifest resource, strip the loose wwwroot, and clean the zip up.
+        // Regression guard for the subtle bug where ResolvePublishDir's second `--getProperty:PublishDir`
+        // evaluation rebuilt the assembly without the (already-deleted) zip and silently undid the embed.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"ryn-embed-int-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(tempDir, "wwwroot"));
+        try
+        {
+            var targets = Path.Combine(RepoRoot(), "src", "Ryn.Core", "build", "Ryn.Core.targets");
+#pragma warning disable CA1849
+            File.WriteAllText(Path.Combine(tempDir, "wwwroot", "index.html"), "<html>EMBED-ME</html>");
+            File.WriteAllText(Path.Combine(tempDir, "App.csproj"),
+                "<Project Sdk=\"Microsoft.NET.Sdk\">"
+                + "<PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net10.0</TargetFramework></PropertyGroup>"
+                + "<ItemGroup><Content Include=\"wwwroot/**\" CopyToOutputDirectory=\"PreserveNewest\" /></ItemGroup>"
+                + $"<Import Project=\"{targets}\" /></Project>");
+            File.WriteAllText(Path.Combine(tempDir, "Program.cs"), "class P{static void Main(){}}");
+#pragma warning restore CA1849
+
+            var result = await RunCliAsync("bundle", tempDir, "--project", Path.Combine(tempDir, "App.csproj"), "--embed");
+
+            result.ExitCode.Should().Be(0, because: $"the bundle must succeed. stdout:\n{result.Stdout}\nstderr:\n{result.Stderr}");
+
+            // The transient staging zip must not survive the build.
+            File.Exists(Path.Combine(tempDir, "ryn_embedded_content.zip")).Should().BeFalse("the staged zip is cleaned up");
+
+            // The published assembly must carry the embedded resource (and the loose content must be gone).
+            var publishedDll = Directory
+                .EnumerateFiles(Path.Combine(tempDir, "bin"), "App.dll", SearchOption.AllDirectories)
+                .FirstOrDefault(p => p.Contains("publish", StringComparison.Ordinal));
+            publishedDll.Should().NotBeNull("publish must have produced App.dll");
+#pragma warning disable CA1849
+            var dllBytes = File.ReadAllBytes(publishedDll!);
+#pragma warning restore CA1849
+            ContainsAscii(dllBytes, "ryn_embedded_content.zip")
+                .Should().BeTrue("the embedded zip resource must be baked into the assembly");
+
+            var publishDir = Path.GetDirectoryName(publishedDll)!;
+            File.Exists(Path.Combine(publishDir, "index.html"))
+                .Should().BeFalse("the loose wwwroot content must be stripped from the publish output when embedding");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task Dev_NoCsproj_ReturnsError()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"ryn-dev-{Guid.NewGuid():N}");
@@ -372,6 +453,36 @@ public sealed class CliCommandTests
             dir = Path.GetDirectoryName(dir);
         }
         throw new InvalidOperationException("Cannot find Ryn.Cli.csproj");
+    }
+
+    /// <summary>Walks up from the test assembly to the repository root (the directory that contains <c>src/</c>).</summary>
+    private static string RepoRoot()
+    {
+        var dir = Path.GetDirectoryName(typeof(CliCommandTests).Assembly.Location)!;
+        while (dir is not null)
+        {
+            if (Directory.Exists(Path.Combine(dir, "src", "Ryn.Core", "build")))
+                return dir;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Cannot find the repository root");
+    }
+
+    /// <summary>True if <paramref name="haystack"/> contains <paramref name="needle"/> as a contiguous ASCII run
+    /// (managed manifest-resource names live in the metadata #Strings heap as UTF-8, so they appear verbatim).</summary>
+    private static bool ContainsAscii(byte[] haystack, string needle)
+    {
+        var pattern = System.Text.Encoding.ASCII.GetBytes(needle);
+        for (var i = 0; i <= haystack.Length - pattern.Length; i++)
+        {
+            var match = true;
+            for (var j = 0; j < pattern.Length; j++)
+            {
+                if (haystack[i + j] != pattern[j]) { match = false; break; }
+            }
+            if (match) return true;
+        }
+        return false;
     }
 
     private sealed record CliResult(int ExitCode, string Stdout, string Stderr);


### PR DESCRIPTION
Fixes two `ryn bundle` issues from a dev bug report.

## 1. `ryn bundle` never embedded content
`ryn build --embed` stages `ryn_embedded_content.zip` and passes `-p:RynEmbedContent=true`, but `ryn bundle` did neither — so the `Ryn.Core.targets` conditions (`RynEmbedContent == true AND Exists(zip)`) both gated out, the binary had no embedded resource or `Ryn.UseEmbeddedContent` metadata, and the app fell back to disk and showed "not found". The loose `wwwroot` also shipped because the Content items copied normally.

- `ryn bundle --embed` now stages the zip, passes the flag, and cleans the zip up (mirrors `ryn build`).
- **Cleanup-order fix:** the zip is deleted only *after* `ResolvePublishDir`. That method runs a second `dotnet publish … --getProperty:PublishDir`, which re-evaluates the project; with the zip already gone it rebuilt the assembly **without** the resource, silently undoing the embed. (Caught by the new end-to-end test, not unit tests.)
- `Ryn.Core.targets` now strips `wwwroot` Content/None from build **and** publish output when `RynEmbedContent=true`, so neither the publish dir nor the bundle ships loose duplicates. Also fixes the same redundant-loose-copy for `ryn build --embed`.
- The Windows/Linux bundlers skip their explicit `wwwroot` copy when embedding.

## 2. `ryn bundle --aot` silently degraded on Windows
On Build Tools installs the VS Installer directory is often not on `PATH`, so AOT's `vswhere.exe` lookup fails, the link step fails, and publish falls back to a framework-dependent build (hundreds of `System.*.dll`) with no clear error.

- New `NativeAotToolchain.Configure`: on Windows + `--aot`, prepend the VS Installer directory to the publish process's `PATH` so `vswhere.exe` resolves; warn clearly when none can be found. Wired into both `bundle` and `build`.

## Tests
- `bundle --help` lists `--embed`; `bundle --embed` with no `wwwroot` fails fast before publishing.
- Integration test: bundles `--embed` end to end and asserts the resource is baked into the assembly, the loose `wwwroot` is stripped, and the staged zip is cleaned up.

Verified locally on macOS (full `bundle --embed` chain: resource embedded, no loose wwwroot, zip cleaned). The Windows `vswhere` path and the cross-platform integration test run on CI.