### PR TITLE
feat: add runtime window setters

### DIFF
--- a/src/Ryn.Core/IRynWindow.cs
+++ b/src/Ryn.Core/IRynWindow.cs
@@ -51,6 +51,12 @@ public interface IRynWindow
     public void ToggleMaximize();
     /// <summary>Moves the window's top-left corner to the given screen coordinates (in points).</summary>
     public void Move(int x, int y);
+    /// <summary>Enters or leaves fullscreen mode.</summary>
+    public void SetFullscreen(bool fullscreen);
+    /// <summary>Sets whether the window stays above other windows.</summary>
+    public void SetAlwaysOnTop(bool alwaysOnTop);
+    /// <summary>Centers the window on its current screen.</summary>
+    public void Center();
     /// <summary>
     /// Initiates a window drag operation (for frameless windows). For dragging a title bar from HTML, prefer
     /// the <c>data-webview-drag</c> attribute instead: it starts the OS drag synchronously inside the mousedown

--- a/src/Ryn.Core/Internal/DeferredRynWindow.cs
+++ b/src/Ryn.Core/Internal/DeferredRynWindow.cs
@@ -59,6 +59,9 @@ internal sealed class DeferredRynWindow(RynWindowAccessor accessor) : IRynWindow
     public void Minimize() => Live.Minimize();
     public void ToggleMaximize() => Live.ToggleMaximize();
     public void Move(int x, int y) => Live.Move(x, y);
+    public void SetFullscreen(bool fullscreen) => Live.SetFullscreen(fullscreen);
+    public void SetAlwaysOnTop(bool alwaysOnTop) => Live.SetAlwaysOnTop(alwaysOnTop);
+    public void Center() => Live.Center();
     public void StartDrag() => Live.StartDrag();
     public void StartResize(WindowEdge edge) => Live.StartResize(edge);
 

--- a/src/Ryn.Core/Ryn.Core.csproj
+++ b/src/Ryn.Core/Ryn.Core.csproj
@@ -10,6 +10,7 @@
     <InternalsVisibleTo Include="Ryn.Core.Tests" />
     <InternalsVisibleTo Include="Ryn.Integration.Tests" />
     <InternalsVisibleTo Include="Ryn.Interop.Tests" />
+    <InternalsVisibleTo Include="Ryn.Ipc.Tests" />
     <InternalsVisibleTo Include="Ryn.Plugins.Dialog" />
     <InternalsVisibleTo Include="Ryn.Plugins.FileSystem" />
     <InternalsVisibleTo Include="Ryn.Plugins.Shell" />

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -211,13 +211,28 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         }
     });
 
-    public void Move(int x, int y) => RunOnUi(() =>
+    public void Move(int x, int y) => RunOnUi(() => { if (_window != null) ApplyPosition(x, y); });
+
+    public void SetFullscreen(bool fullscreen) =>
+        RunOnUi(() => { if (_window != null) Saucer.saucer_window_set_fullscreen(_window, (byte)(fullscreen ? 1 : 0)); });
+
+    public void SetAlwaysOnTop(bool alwaysOnTop) =>
+        RunOnUi(() => { if (_window != null) Saucer.saucer_window_set_always_on_top(_window, (byte)(alwaysOnTop ? 1 : 0)); });
+
+    public void Center() => RunOnUi(() =>
     {
         if (_window == null) return;
+        if (TryComputeCenter(out var x, out var y)) ApplyPosition(x, y);
+    });
+
+    /// <summary>Applies a new top-left and updates the cached/normal-position bookkeeping (so a later restore from
+    /// maximized returns here). Caller must hold the UI thread and have checked <c>_window != null</c>.</summary>
+    private void ApplyPosition(int x, int y)
+    {
         Saucer.saucer_window_set_position(_window, x, y);
         _cachedX = x; _cachedY = y;
         if (Saucer.saucer_window_maximized(_window) == 0) { _normalX = x; _normalY = y; }
-    });
+    }
 
     public void StartDrag() => RunOnUi(() => { if (_window != null) Saucer.saucer_window_start_drag(_window); });
 
@@ -807,6 +822,25 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         var maxX = sx + Math.Max(0, sw - width);
         var maxY = sy + Math.Max(0, sh - height);
         return (Math.Clamp(x, sx, maxX), Math.Clamp(y, sy, maxY));
+    }
+
+    /// <summary>Computes the top-left that centers the window on its current screen. Returns false (leaving the
+    /// window put) if the screen bounds can't be read. Mirrors <see cref="ClampToScreen"/>'s native reads; must
+    /// run on the UI thread.</summary>
+    private bool TryComputeCenter(out int x, out int y)
+    {
+        x = 0; y = 0;
+        var screen = Saucer.saucer_window_screen(_window);
+        if (screen == null) return false;
+        int sx, sy, sw, sh, w, h;
+        Saucer.saucer_screen_position(screen, &sx, &sy);
+        Saucer.saucer_screen_size(screen, &sw, &sh);
+        Saucer.saucer_screen_free(screen);
+        if (sw <= 0 || sh <= 0) return false;
+        Saucer.saucer_window_size(_window, &w, &h);
+        x = sx + Math.Max(0, (sw - w) / 2);
+        y = sy + Math.Max(0, (sh - h) / 2);
+        return true;
     }
 
     /// <summary>

--- a/src/Ryn.Ipc/WindowCommands.cs
+++ b/src/Ryn.Ipc/WindowCommands.cs
@@ -43,6 +43,18 @@ internal sealed class WindowCommands
         _windows.Current.Height = height;
     }
 
+    [RynCommand("window.setPosition")]
+    public void SetPosition(int x, int y) => _windows.Current.Move(x, y);
+
+    [RynCommand("window.setFullscreen")]
+    public void SetFullscreen(bool fullscreen) => _windows.Current.SetFullscreen(fullscreen);
+
+    [RynCommand("window.setAlwaysOnTop")]
+    public void SetAlwaysOnTop(bool alwaysOnTop) => _windows.Current.SetAlwaysOnTop(alwaysOnTop);
+
+    [RynCommand("window.center")]
+    public void Center() => _windows.Current.Center();
+
     /// <summary>Returns the id of the window whose page invoked this command.</summary>
     [RynCommand("window.current")]
     public int Current() => _windows.Current.Id;

--- a/tests/Ryn.Ipc.Tests/WindowCommandsTests.cs
+++ b/tests/Ryn.Ipc.Tests/WindowCommandsTests.cs
@@ -1,0 +1,81 @@
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Ryn.Core;
+using Ryn.Core.Internal;
+using Xunit;
+
+namespace Ryn.Ipc.Tests;
+
+/// <summary>
+/// Drives the new window setter commands through the full JS-to-C# path: serialized JSON args go through
+/// RynCommandDispatcher, the source-generated WindowCommandsRouter, the [RynCommand] handler, and out to the
+/// originating window resolved from the ambient <see cref="CurrentWindow"/>. Asserts each forwards to the
+/// correct <see cref="IRynWindow"/> member with the camelCase args parsed correctly.
+/// </summary>
+public sealed class WindowCommandsTests
+{
+    [Fact]
+    public async Task SetFullscreen_ForwardsToCurrentWindow()
+    {
+        var (dispatcher, window) = BuildWindowDispatcher();
+
+        CurrentWindow.Value = window;
+        try { await dispatcher.DispatchAsync("window.setFullscreen", JsonArgs("{\"fullscreen\":true}")); }
+        finally { CurrentWindow.Value = null; }
+
+        window.Received(1).SetFullscreen(true);
+    }
+
+    [Fact]
+    public async Task SetAlwaysOnTop_ForwardsToCurrentWindow()
+    {
+        var (dispatcher, window) = BuildWindowDispatcher();
+
+        CurrentWindow.Value = window;
+        try { await dispatcher.DispatchAsync("window.setAlwaysOnTop", JsonArgs("{\"alwaysOnTop\":true}")); }
+        finally { CurrentWindow.Value = null; }
+
+        window.Received(1).SetAlwaysOnTop(true);
+    }
+
+    [Fact]
+    public async Task Center_ForwardsToCurrentWindow()
+    {
+        var (dispatcher, window) = BuildWindowDispatcher();
+
+        CurrentWindow.Value = window;
+        try { await dispatcher.DispatchAsync("window.center", ReadOnlyMemory<byte>.Empty); }
+        finally { CurrentWindow.Value = null; }
+
+        window.Received(1).Center();
+    }
+
+    [Fact]
+    public async Task SetPosition_ForwardsToMoveWithParsedCoordinates()
+    {
+        var (dispatcher, window) = BuildWindowDispatcher();
+
+        CurrentWindow.Value = window;
+        try { await dispatcher.DispatchAsync("window.setPosition", JsonArgs("{\"x\":10,\"y\":20}")); }
+        finally { CurrentWindow.Value = null; }
+
+        window.Received(1).Move(10, 20);
+    }
+
+    private static (RynCommandDispatcher Dispatcher, IRynWindow Window) BuildWindowDispatcher()
+    {
+        var window = Substitute.For<IRynWindow>();
+        var services = new ServiceCollection();
+        services.AddSingleton(new CurrentWindowAccessor(new NativeApplicationAccessor()));
+        services.AddSingleton(Substitute.For<IRynWindowManager>());
+        services.AddWindowCommands();
+        var provider = services.BuildServiceProvider();
+
+        var routers = provider.GetServices<ICommandRouter>().ToArray();
+        return (new RynCommandDispatcher(routers, provider, RynCapabilities.AllowAll()), window);
+    }
+
+    private static ReadOnlyMemory<byte> JsonArgs(string json) => Encoding.UTF8.GetBytes(json);
+}


### PR DESCRIPTION
Adds runtime window state controls (targets v0.4.0).

- `SetFullscreen`, `SetAlwaysOnTop`, `Center` on `IRynWindow`/`RynWindow` (positioning already had `Move`), backed by the saucer window setters
- `window.setFullscreen`/`setAlwaysOnTop`/`center`/`setPosition` IPC commands
- `ApplyPosition` helper shared by `Move` and `Center`
- Forwards the new members through `DeferredRynWindow`
- Tests the new commands end to end through the generated router