### PR TITLE
feat: add cross-origin isolation (COOP/COEP) for SharedArrayBuffer

### DIFF
--- a/docs/gpu-rendering.md
+++ b/docs/gpu-rendering.md
@@ -1,0 +1,325 @@
+# GPU-accelerated rendering in Ryn
+
+How to build a smooth, GPU-accelerated rendering surface (a map editor, a node
+graph, a sprite-heavy canvas, a 2D game) inside a Ryn webview — and how to make
+sure you are actually on the GPU and not silently falling back to software.
+
+> **Short version.** The GPU is *already on* in every Ryn backend. There is no
+> magic toggle that makes a slow renderer fast. Lag in a canvas-heavy app is
+> almost always the **rendering approach**, not a disabled flag: drawing thousands
+> of objects with the DOM or the Canvas 2D API runs on the CPU and hits a wall.
+> The fix is to draw through **WebGL** — in practice, via a batching library like
+> **PixiJS** — so the work goes to the GPU as a handful of draw calls instead of
+> thousands. That is what closes the gap with a native engine like Godot.
+
+---
+
+## 1. The mental model: who does the drawing?
+
+A webview can paint pixels several different ways, and they do *not* cost the same:
+
+| How you draw | Where the work runs | Scales to… |
+|---|---|---|
+| **DOM + CSS** (divs, absolute positioning) | Layout + paint on the **CPU** main thread | Hundreds of static nodes. Moving many nodes per frame triggers reflow and stalls everything. |
+| **Canvas 2D** (`ctx.drawImage`, `fillRect`) | CPU-orchestrated; GPU-backed only under browser heuristics | A few hundred to low-thousands of objects before jank. |
+| **WebGL / WebGL2** (raw, or via PixiJS / three.js) | **GPU**, talking to Direct3D / Metal / OpenGL under the hood | Tens to hundreds of thousands of sprites if batched. |
+| **WebGPU** | **GPU**, lower CPU overhead + compute | Highest — but not available on every platform yet (see §4). |
+
+**This is what "switch the backend to OpenGL / three.js" meant.** WebGL is
+essentially OpenGL ES exposed to JavaScript — it talks straight to the GPU. You
+almost never write raw WebGL; you use a library that wraps it. So "switching the
+backend" does not mean changing anything in Ryn or C# — it means changing **which
+drawing API your front-end JavaScript uses for the viewport**: from DOM/Canvas 2D
+(CPU) to WebGL-via-PixiJS (GPU).
+
+The GPU was available the whole time. The lag came from feeding it work through a
+CPU-bound API.
+
+---
+
+## 2. The Ryn knobs (and what they do *not* do)
+
+Ryn exposes two relevant options on both `RynOptions` (app-wide) and
+`RynWindowOptions` (per secondary window). Shipped in PR #32.
+
+### `HardwareAcceleration` — `bool`, default `true`
+
+GPU compositing for the whole webview. **It is on by default**, which is what you
+want for canvas/WebGL/WebGPU. The only reason to set it `false` is as a
+compatibility escape hatch for flaky GPU drivers or headless/virtualized
+environments — turning it off makes everything slower. It is applied once, before
+the webview is created, so it can't change for a live window.
+
+```csharp
+var app = RynApplication.CreateBuilder()
+    .ConfigureOptions(opts =>
+    {
+        opts.Title = "Map Editor";
+        opts.Width = 1280;
+        opts.Height = 800;
+        // opts.HardwareAcceleration is already true — leave it on.
+    })
+    .Build();
+```
+
+> **There is no "make it fast" toggle beyond this.** If your renderer is slow with
+> `HardwareAcceleration = true`, the problem is in your JS rendering code, not Ryn.
+
+### `BrowserFlags` — `IList<string>`, the per-engine escape hatch
+
+Engine-specific flags applied before the webview is created — the lever for
+opting into experimental rendering features. **The syntax is not portable**,
+because each OS runs a different engine. Always guard a flag behind an OS check.
+
+```csharp
+.ConfigureOptions(opts =>
+{
+    if (OperatingSystem.IsWindows())
+    {
+        // WebView2 / Chromium command-line switches:
+        opts.BrowserFlags.Add("--ignore-gpu-blocklist");   // force GPU on blocklisted hardware
+        // opts.BrowserFlags.Add("--enable-unsafe-webgpu"); // only needed on ARM64; not on Win x64
+        // opts.BrowserFlags.Add("--use-angle=d3d11");      // pick the ANGLE backend
+    }
+    // macOS (WKWebView): key=value pairs applied to WKWebViewConfiguration (value parsed as JSON).
+    // Linux (WebKitGTK): WebKit feature/setting flags. For GPU issues on Linux you usually want
+    //                    environment variables instead — see §3.
+})
+```
+
+You can also set both from `ryn.json` / configuration: a `HardwareAcceleration`
+boolean and a `BrowserFlags` array. They project onto secondary windows too.
+
+---
+
+## 3. Are you actually on the GPU? (verify the fallback)
+
+The single most common cause of "why is this so slow" is a **silent software
+fallback** — the webview couldn't use the GPU and quietly switched to a CPU
+rasterizer (Chromium's *SwiftShader*, Mesa's *llvmpipe*). Everything still renders,
+just at a fraction of the speed.
+
+Log the real renderer string on startup:
+
+```js
+function gpuRenderer() {
+  const c = document.createElement('canvas');
+  const gl = c.getContext('webgl2') || c.getContext('webgl');
+  if (!gl) return 'NO WEBGL';
+  const ext = gl.getExtension('WEBGL_debug_renderer_info');
+  return ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : 'unknown';
+}
+const r = gpuRenderer();
+console.log('GPU renderer:', r);
+if (/swiftshader|llvmpipe|software|basic render/i.test(r)) {
+  console.warn('SOFTWARE FALLBACK — not using the GPU!');
+}
+```
+
+What you want to see:
+- **Windows / WebView2:** `ANGLE (..., Direct3D11 ...)` — good. `SwiftShader` or
+  `Microsoft Basic Render Driver` — software fallback (bad).
+- **Linux / WebKitGTK:** a real GPU name — good. `llvmpipe` or `Software` — software (bad).
+- **macOS / WKWebView:** WebKit **masks** the renderer to a generic `"Apple GPU"`,
+  so this check can't distinguish hardware from software on macOS. Judge by frame
+  timing instead. In practice macOS WKWebView is hardware-accelerated (ANGLE → Metal)
+  and "just works".
+
+If you see a software fallback on **Windows**, try `--ignore-gpu-blocklist` (and,
+if needed, `--use-angle=d3d11`) via `BrowserFlags`. Newer WebView2 runtimes are
+moving to *fail* WebGL rather than fall back silently, so also handle the
+context-creation-fails case.
+
+If you see `llvmpipe` on **Linux**, it's an environment/driver issue, not a Ryn
+setting. The relevant levers are **environment variables set before launch**, not
+`BrowserFlags`:
+- `WEBKIT_DISABLE_COMPOSITING_MODE=1` — fixes blank/garbled windows under software GL.
+- `WEBKIT_DISABLE_DMABUF_RENDERER=1` — common NVIDIA / VM workaround.
+- `LIBGL_ALWAYS_SOFTWARE=1` / `GALLIUM_DRIVER=llvmpipe` — these *force* software; make
+  sure they aren't set in your environment.
+
+---
+
+## 4. WebGL vs WebGPU — what's available where (as of mid-2026)
+
+**WebGL2 is hardware-accelerated by default on all three backends.** It is the
+correct default target for a 2D map editor and works everywhere Ryn runs.
+
+**WebGPU is faster but not yet a cross-platform default:**
+
+| Backend | WebGL2 | WebGPU |
+|---|---|---|
+| **WebView2 (Windows)** | ✅ default (ANGLE → D3D11) | ✅ default (Chromium 113+, via D3D12) |
+| **WKWebView (macOS)** | ✅ default (ANGLE → Metal) | ⚠️ only on **macOS Tahoe 26+** (`navigator.gpu` is `undefined` on Sonoma/Sequoia) |
+| **WebKitGTK (Linux)** | ✅ default | ❌ **not available at all** |
+
+**Conclusion: build on WebGL2, feature-detect WebGPU, never assume it.** A Ryn app
+that requires WebGPU would be broken on Linux and on pre-Tahoe Macs. The clean way
+to get "WebGPU where available, WebGL2 everywhere else" is to use a library that
+auto-selects the backend (PixiJS does this) and to guard any direct WebGPU code
+with `if ('gpu' in navigator)`.
+
+---
+
+## 5. Library recommendation
+
+**Use PixiJS v8 for the rendering viewport.** Reasons:
+
+- It auto-detects the backend: **WebGPU where available, automatic WebGL2 fallback
+  otherwise** — exactly the cross-platform story above, for free.
+- **Automatic sprite batching:** sprites sharing a texture atlas / blend mode
+  collapse into one or two draw calls. Draw-call count is *the* binding constraint;
+  batching is what makes thousands of objects cheap.
+- It is the benchmarked top performer for 2D.
+
+Plan for these gaps (Pixi is a renderer, not an editor framework):
+- **Pan/zoom** isn't in core — add the [`pixi-viewport`](https://github.com/pixijs-userland/pixi-viewport)
+  plugin (drag / pinch / wheel-zoom / clamp).
+- **Culling** is off by default — set `cullable = true` or cull to the viewport yourself.
+- **Selection handles** you build yourself.
+- **Test the WebGPU→WebGL fallback on real target hardware** — it has had reported bugs.
+
+**Alternative — Konva.** If your editor is more "a few hundred to low-thousands of
+selectable shapes" than "a sprite-heavy tilemap," Konva gives you a built-in
+selection `Transformer` (drag/resize/rotate handles), layers, hit-detection, JSON
+serialization, and React/Vue/Svelte bindings out of the box. The trade-off: it's
+**Canvas 2D**, so it won't match WebGL once object counts climb into the thousands.
+
+**three.js** only if you also need real 3D (its WebGPU renderer is still officially
+"experimental"). **regl / raw WebGL** only for a fully bespoke renderer.
+
+> Typical map-editor architecture: **PixiJS for the canvas viewport** (tiles +
+> sprites, batched, culled) and ordinary HTML/CSS (or your framework) for the
+> surrounding panels, toolbars, and inspectors.
+
+---
+
+## 6. Architecture patterns that kill lag
+
+These matter more than any flag. A map editor that follows them will feel native.
+
+1. **Render on demand, not on a permanent loop.** Don't run a `requestAnimationFrame`
+   loop that redraws every frame forever. Mark the scene "dirty" on change, coalesce
+   bursty input (mousemove, wheel) into **at most one redraw per animation frame**,
+   and only run a continuous loop while something is actually animating (inertial pan,
+   animated tiles). An idle editor should be drawing **zero** frames.
+2. **Batch + texture atlases.** Pack all your tile/sprite art into a few atlas
+   textures. A texture switch flushes the batch, so interleaving many separate images
+   or blend modes destroys batching. One atlas → one draw call for the whole layer.
+3. **Cull to the viewport.** Only draw tiles/objects that are on or near screen. For
+   very large maps, chunk the world and load/unload regions around the camera. A
+   10,000×10,000 tile map should still only draw the ~hundreds of tiles you can see.
+4. **Render the tile layer as a tilemap, not N sprites.** The efficient WebGL
+   technique draws the visible map as a single quad and looks up each tile in a
+   fragment shader (PixiJS has tilemap helpers), instead of one sprite object per tile.
+5. **No per-frame allocations.** Creating objects/arrays inside the render loop feeds
+   the garbage collector, and GC pauses are the #1 cause of stutter. Reuse objects;
+   pool them.
+6. **Create the WebGL context once.** Contexts are heavyweight and limited in number —
+   never recreate the canvas/context per frame.
+7. **OffscreenCanvas + a Web Worker** moves rendering off the main thread so UI input
+   stays responsive (feature-detect `'OffscreenCanvas' in window`; keep a main-thread
+   fallback for older engine versions). Note this does **not** require
+   `SharedArrayBuffer` — see the Ryn caveat below.
+8. **Keep per-frame data inside the webview.** Never push image/vertex/tile buffers
+   across the C#↔JS IPC boundary every frame — the bridge serializes payloads. Do all
+   rendering inside JS/WebGL; use Ryn's IPC layer only for **load / save / commands**,
+   passing file paths or handles, not pixel data.
+9. **Handle `devicePixelRatio`** for crisp HiDPI, but remember it multiplies pixel
+   cost (dpr 2 → 4× the pixels). Capping the backing store at ~1.5–2× is common even
+   when the OS reports more.
+10. **Don't let the surrounding DOM fight the canvas.** Heavy CSS effects
+    (`backdrop-blur`, animated shadows) and layout thrash on the page compete with the
+    renderer for the main thread.
+
+---
+
+## 7. `SharedArrayBuffer`, multithreaded WASM, and Blazor — the `CrossOriginIsolation` option
+
+Some of the heaviest paths — **multithreaded WebAssembly** (a threaded
+Emscripten/Godot-web build, a Rust/WASM renderer using threads, or **multithreaded
+Blazor WASM**) and cross-thread pixel-buffer sharing — require `SharedArrayBuffer`,
+which the browser only enables when the page is **cross-origin isolated**. That
+requires `Cross-Origin-Opener-Policy: same-origin` +
+`Cross-Origin-Embedder-Policy: require-corp` on the document (and
+`Cross-Origin-Resource-Policy` on same-origin subresources).
+
+**Ryn ships this as a one-line opt-in:**
+
+```csharp
+.ConfigureOptions(opts =>
+{
+    opts.CrossOriginIsolation = true;   // emits COOP/COEP/CORP on ryn:// and the local server
+})
+```
+
+(or `"CrossOriginIsolation": true` in `ryn.json`). It applies to the `ryn://` scheme
+handler *and* the local HTTP server, and projects onto secondary windows. With it on:
+
+- `window.crossOriginIsolated === true`, so `SharedArrayBuffer` is available.
+- **Caveat 1 (subresources):** under COEP `require-corp`, cross-origin subresources (a
+  CDN script, a remote font) must send their own CORP/CORS headers or the browser
+  blocks them. Keep assets same-origin (bundled) or ensure the remote sends them.
+- **Caveat 2 (secure context — important):** `crossOriginIsolated` also requires a
+  *secure context*. `http://localhost` (the local server) qualifies, but the `ryn://`
+  custom scheme may **not** be treated as a secure context on WebKit (macOS/Linux) — so
+  the headers can be correct yet `crossOriginIsolated` stays `false`. **If you need
+  `SharedArrayBuffer`, serve over the local server** (`UseLocalServer = true`) alongside
+  `CrossOriginIsolation = true`, rather than the default `ryn://` content path. Verify
+  with `console.log(window.crossOriginIsolated)` after load.
+
+What needs it vs. what doesn't:
+
+- **Plain WebGL / WebGPU / PixiJS** — does **not** need it. Leave it off.
+- **OffscreenCanvas + Worker rendering** — does **not** need it (`transferControlToOffscreen`
+  works without `SharedArrayBuffer`).
+- **Multithreaded WASM / threaded Godot-web / Rust+wasm-threads** — **needs it on**.
+- **Blazor WebAssembly** — single-threaded Blazor works without it; **multithreaded
+  Blazor WASM needs it on**. (Dev-server note: if you serve Blazor from an external
+  dev server via `RynOptions.Url`, that server must send COOP/COEP itself — Ryn only
+  controls the `ryn://` scheme and its own local server, not your external dev server.)
+
+So for the **map editor** with PixiJS: leave `CrossOriginIsolation` off. Flip it on
+only if you move to a threaded WASM renderer or multithreaded Blazor.
+
+---
+
+## 8. Diagnosing a slow renderer — checklist
+
+1. **Log the renderer string** (§3). Software fallback? Fix that first.
+2. **Open DevTools → Performance**, record while panning/editing. Look for:
+   - red bar over the FPS track (framerate hurting UX),
+   - long tasks (>50 ms) on the main thread (red-triangle marks),
+   - purple Layout events with red triangles (forced reflow / layout thrash).
+   - Throttle the CPU 4–20× to surface jank your dev machine hides.
+3. **Check the usual culprits:**
+   - `getImageData()` / `toDataURL()` readback, or `willReadFrequently: true` →
+     flips the canvas to **software CPU**. Avoid in the hot path.
+   - Per-frame `new` / array allocations → GC stutter.
+   - Recreating contexts/canvases per frame.
+   - Canvas 2D or DOM for thousands of objects → the headline cause. Move to PixiJS.
+   - A permanent rAF loop redrawing an idle scene → switch to render-on-demand.
+
+---
+
+## 9. Starter recipe for the map editor
+
+1. Front-end: render the viewport with **PixiJS v8**; keep panels/toolbars in
+   HTML/CSS (or your framework).
+2. Add **`pixi-viewport`** for pan/zoom; turn on **culling**; draw the tile layer as
+   a **tilemap / atlas-batched** sprites, not one object per tile.
+3. **Render on demand** — redraw only when the scene changes; coalesce input to one
+   frame.
+4. On startup, **log `UNMASKED_RENDERER_WEBGL`** and warn on `swiftshader`/`llvmpipe`
+   (skip the assertion on macOS, where it's masked).
+5. **Feature-detect `navigator.gpu`**; let PixiJS pick WebGPU vs WebGL2. Never require
+   WebGPU (Linux has none; macOS needs Tahoe 26+).
+6. Keep `HardwareAcceleration = true` (default). Add Windows-only
+   `--ignore-gpu-blocklist` via `BrowserFlags` *only* if §3 shows a software fallback.
+7. Do **all** rendering in JS/WebGL; use Ryn IPC only for open/save/commands — never
+   per-frame pixel data.
+
+Done right, a webview-based 2D editor matches a native one for this workload —
+Godot's own web export is itself a WebAssembly + WebGL2 canvas renderer, so "web
+rendering" is not inherently second-class. The lag you were fighting was
+architecture, not the platform.

--- a/docs/plan/PLAN.md
+++ b/docs/plan/PLAN.md
@@ -1,5 +1,9 @@
 # Ryn — Project Plan
 
+> **SUPERSEDED / HISTORICAL (2026-06-30):** this is the original phased plan. Many "not yet / SKIPPED"
+> notes are stale (Windows/Linux builds, MSI, AppImage, tray, updater all shipped; complex IPC types work).
+> For current status see `docs/ROADMAP.md`; delivered features are documented under `docs/`.
+
 **Rich Yet Native** — A cross-platform, lightweight .NET framework for building desktop applications with web UIs.
 
 ---

--- a/src/Ryn.Core/Internal/LocalWebServer.cs
+++ b/src/Ryn.Core/Internal/LocalWebServer.cs
@@ -26,6 +26,7 @@ internal sealed class LocalWebServer : IAsyncDisposable
     private readonly string? _contentDirectory;
     private EmbeddedContentStore? _embeddedContent;
     private readonly string? _allowedCorsOrigin;
+    private readonly bool _crossOriginIsolation;
     private readonly int _preferredPort;
     private ILocalServerHost? _webView;
     private TcpListener? _listener;
@@ -41,11 +42,13 @@ internal sealed class LocalWebServer : IAsyncDisposable
     /// <param name="contentDirectory">Static content root, or null for an IPC-only server (e.g. backing a Vite dev server).</param>
     /// <param name="preferredPort">Fixed loopback port to try first.</param>
     /// <param name="allowedCorsOrigin">When set (e.g. a dev-server origin), cross-origin IPC from that origin is permitted via CORS.</param>
-    internal LocalWebServer(string? contentDirectory, int preferredPort, string? allowedCorsOrigin = null)
+    /// <param name="crossOriginIsolation">When true, static responses send COOP/COEP/CORP so the page is crossOriginIsolated (SharedArrayBuffer).</param>
+    internal LocalWebServer(string? contentDirectory, int preferredPort, string? allowedCorsOrigin = null, bool crossOriginIsolation = false)
     {
         _contentDirectory = contentDirectory is null ? null : Path.GetFullPath(contentDirectory);
         _preferredPort = preferredPort > 0 ? preferredPort : DefaultPort;
         _allowedCorsOrigin = allowedCorsOrigin?.TrimEnd('/');
+        _crossOriginIsolation = crossOriginIsolation;
     }
 
     internal void SetWebView(ILocalServerHost webView) => _webView = webView;
@@ -496,6 +499,15 @@ internal sealed class LocalWebServer : IAsyncDisposable
             ("Cache-Control", "no-cache, no-store, must-revalidate"),
             ("X-Content-Type-Options", "nosniff"),
         };
+
+        // Cross-origin isolation: COOP+COEP on the document make the page crossOriginIsolated (enabling
+        // SharedArrayBuffer / threaded WASM); CORP lets same-origin subresources load under COEP require-corp.
+        if (_crossOriginIsolation)
+        {
+            headers.Add(("Cross-Origin-Opener-Policy", "same-origin"));
+            headers.Add(("Cross-Origin-Embedder-Policy", "require-corp"));
+            headers.Add(("Cross-Origin-Resource-Policy", "same-origin"));
+        }
 
         // Embedded content (bundled): serve from the in-memory map, SPA-falling back to index.html. This is what
         // lets UseLocalServer compose with embedded content — a bundled single binary served over http://localhost

--- a/src/Ryn.Core/RynApplicationBuilder.cs
+++ b/src/Ryn.Core/RynApplicationBuilder.cs
@@ -239,6 +239,9 @@ public sealed class RynApplicationBuilder
         if (section[nameof(RynOptions.HardwareAcceleration)] is { } hwAccel && bool.TryParse(hwAccel, out var hw))
             options.HardwareAcceleration = hw;
 
+        if (section[nameof(RynOptions.CrossOriginIsolation)] is { } coi && bool.TryParse(coi, out var ci))
+            options.CrossOriginIsolation = ci;
+
         // Url intentionally excluded — Uri binding needs TypeConverter reflection, keep code-only
     }
 
@@ -272,6 +275,7 @@ public sealed class RynApplicationBuilder
         CopyIfSet(target, source, nameof(RynOptions.PersistWindowState), static (t, s) => t.PersistWindowState = s.PersistWindowState);
         CopyIfSet(target, source, nameof(RynOptions.CaptureUnhandledExceptions), static (t, s) => t.CaptureUnhandledExceptions = s.CaptureUnhandledExceptions);
         CopyIfSet(target, source, nameof(RynOptions.DisableDefaultLogging), static (t, s) => t.DisableDefaultLogging = s.DisableDefaultLogging);
+        CopyIfSet(target, source, nameof(RynOptions.CrossOriginIsolation), static (t, s) => t.CrossOriginIsolation = s.CrossOriginIsolation);
 
         // Get-only collections aren't config-bound, so a non-empty programmatic collection simply replaces
         // the (empty) target. An empty programmatic collection is treated as "not configured" and left alone.

--- a/src/Ryn.Core/RynOptions.cs
+++ b/src/Ryn.Core/RynOptions.cs
@@ -38,6 +38,7 @@ public sealed class RynOptions
     private bool _persistWindowState;
     private bool _captureUnhandledExceptions;
     private bool _disableDefaultLogging;
+    private bool _crossOriginIsolation;
 
     /// <summary>Reverse-DNS application identifier (e.g. "com.example.myapp").</summary>
     public string ApplicationId { get => _applicationId; set => Set(ref _applicationId, value); }
@@ -141,6 +142,23 @@ public sealed class RynOptions
     /// messages — e.g. a plugin that failed to initialize — are visible out of the box).
     /// </summary>
     public bool DisableDefaultLogging { get => _disableDefaultLogging; set => Set(ref _disableDefaultLogging, value); }
+
+    /// <summary>
+    /// When true, static-content responses (the ryn:// scheme handler and the local HTTP server) send
+    /// <c>Cross-Origin-Opener-Policy: same-origin</c>, <c>Cross-Origin-Embedder-Policy: require-corp</c> and
+    /// <c>Cross-Origin-Resource-Policy: same-origin</c>. That makes the page <c>crossOriginIsolated</c> and
+    /// enables <c>SharedArrayBuffer</c> — required by multithreaded WebAssembly (threaded Emscripten/Godot-web
+    /// builds, Rust/WASM threads) and multithreaded Blazor WASM. Default false. Plain WebGL/WebGPU/canvas and
+    /// OffscreenCanvas+Worker rendering do NOT need it. Caveat: with isolation on, cross-origin subresources
+    /// (e.g. a CDN) must send their own CORP/CORS headers or the browser blocks them. Applied per response, so
+    /// it takes effect on the next content load.
+    /// <para><b>Secure-context requirement:</b> <c>crossOriginIsolated</c> also requires a secure context. The
+    /// local HTTP server path (<see cref="UseLocalServer"/>, <c>http://localhost</c>) qualifies; the default
+    /// <c>ryn://</c> custom scheme may not be treated as a secure context on some engines (notably WebKit on
+    /// macOS/Linux), in which case the headers are correct but <c>crossOriginIsolated</c> stays false. If you
+    /// need <c>SharedArrayBuffer</c>, pair this with <see cref="UseLocalServer"/>.</para>
+    /// </summary>
+    public bool CrossOriginIsolation { get => _crossOriginIsolation; set => Set(ref _crossOriginIsolation, value); }
 
     /// <summary>Custom URL schemes to register for deep linking (e.g., "myapp").</summary>
     public IList<string> DeepLinkSchemes { get; } = new List<string>();

--- a/src/Ryn.Core/RynWebView.cs
+++ b/src/Ryn.Core/RynWebView.cs
@@ -224,6 +224,7 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
     // HTML content to serve from ryn://app/
     private string? _htmlContent;
     private string? _contentDirectory;
+    private bool _crossOriginIsolation;
     private EmbeddedContentStore? _embeddedContent;
     private readonly HashSet<string> _allowedOrigins = new(StringComparer.OrdinalIgnoreCase) { IpcProtocol.AppOrigin };
 
@@ -302,6 +303,8 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
     internal void SetHtmlContent(string html) => _htmlContent = html;
 
     internal void SetContentDirectory(string path) => _contentDirectory = Path.GetFullPath(path);
+
+    internal void SetCrossOriginIsolation(bool enabled) => _crossOriginIsolation = enabled;
 
     internal void SetEmbeddedContent(EmbeddedContentStore store) => _embeddedContent = store;
 
@@ -709,6 +712,7 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
                 Span<byte> mimeBuf = stackalloc byte[16];
                 var mime = Utf8String.Create("text/html", mimeBuf);
                 var response = Saucer.saucer_scheme_response_new(stash, mime.Pointer);
+                AppendCrossOriginIsolationHeaders(response);
                 Saucer.saucer_scheme_executor_accept(executor, response);
                 // accept() copies the response; we still own (and must free) both native objects.
                 Saucer.saucer_scheme_response_free(response);
@@ -727,12 +731,12 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
     // work. Move to the copied-executor async pattern used for commands (saucer_scheme_executor_copy + async
     // accept, refcounted via TryBeginNativeResponse/EndNativeResponse) and add Range handling. Deferred: it is
     // gated on the INT-03 executor-lifetime work landing first. Tracked in PLAN.md's performance backlog.
-    private static unsafe void ServeFile(saucer_scheme_executor* executor, string filePath) =>
+    private unsafe void ServeFile(saucer_scheme_executor* executor, string filePath) =>
         ServeBytes(executor, File.ReadAllBytes(filePath), GetMimeType(Path.GetExtension(filePath)));
 
     /// <summary>Serves a response body from memory over the app scheme — shared by the on-disk file path and the
     /// in-memory embedded-content path.</summary>
-    private static unsafe void ServeBytes(saucer_scheme_executor* executor, byte[] bytes, string mimeType)
+    private unsafe void ServeBytes(saucer_scheme_executor* executor, byte[] bytes, string mimeType)
     {
         fixed (byte* ptr = bytes)
         {
@@ -740,6 +744,7 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
             Span<byte> mimeBuf = stackalloc byte[128];
             var mime = Utf8String.Create(mimeType, mimeBuf);
             var response = Saucer.saucer_scheme_response_new(stash, mime.Pointer);
+            AppendCrossOriginIsolationHeaders(response);
             Saucer.saucer_scheme_executor_accept(executor, response);
             Saucer.saucer_scheme_response_free(response);
             Saucer.saucer_stash_free(stash);
@@ -1169,6 +1174,16 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
         Saucer.saucer_scheme_response_append_header(response, hdr.Pointer, val.Pointer);
         hdr.Dispose();
         val.Dispose();
+    }
+
+    /// <summary>Appends COOP/COEP/CORP to a static-content response when cross-origin isolation is enabled, so the
+    /// page is <c>crossOriginIsolated</c> (SharedArrayBuffer / threaded WASM). No-op otherwise.</summary>
+    private unsafe void AppendCrossOriginIsolationHeaders(saucer_scheme_response* response)
+    {
+        if (!_crossOriginIsolation) return;
+        AppendHeader(response, "Cross-Origin-Opener-Policy", "same-origin");
+        AppendHeader(response, "Cross-Origin-Embedder-Policy", "require-corp");
+        AppendHeader(response, "Cross-Origin-Resource-Policy", "same-origin");
     }
 
     private static unsafe string ReadRequestBody(saucer_scheme_request* request)

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -426,6 +426,10 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         if (_rynWebView == null || _webview == null)
             return;
 
+        // Cross-origin isolation (COOP/COEP/CORP) applies to ryn:// scheme content; the local-server path passes
+        // it through its constructor below. Harmless on the dev-server/remote paths (they don't serve via ryn://).
+        _rynWebView.SetCrossOriginIsolation(_options.CrossOriginIsolation);
+
         if (_options.Url != null)
         {
             var url = _options.Url;
@@ -463,7 +467,7 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
             // Local HTTP server: a real http://localhost origin (some scripts — e.g. Cloudflare Turnstile —
             // reject the ryn:// origin). Composes both content sources: it serves embedded content from memory
             // when bundled and falls back to the content directory on disk in dev.
-            _localServer = new LocalWebServer(_options.ContentDirectory, _options.LocalServerPort);
+            _localServer = new LocalWebServer(_options.ContentDirectory, _options.LocalServerPort, crossOriginIsolation: _options.CrossOriginIsolation);
             if (_options.EmbeddedContent != null) _localServer.SetEmbeddedContent(_options.EmbeddedContent);
             _localServer.StartAsync().GetAwaiter().GetResult();
             _localServer.SetWebView(_rynWebView);

--- a/src/Ryn.Core/RynWindowOptions.cs
+++ b/src/Ryn.Core/RynWindowOptions.cs
@@ -48,6 +48,11 @@ public sealed class RynWindowOptions
     /// platforms; see <see cref="RynOptions.BrowserFlags"/> for the per-engine format.</summary>
     public IList<string> BrowserFlags { get; } = new List<string>();
 
+    /// <summary>When true, static-content responses send COOP/COEP/CORP headers so the page is
+    /// <c>crossOriginIsolated</c> and <c>SharedArrayBuffer</c> works — required by multithreaded WASM / Blazor.
+    /// Default false. See <see cref="RynOptions.CrossOriginIsolation"/> for the full contract.</summary>
+    public bool CrossOriginIsolation { get; set; }
+
     /// <summary>URL to navigate to on open. Mutually exclusive with <see cref="Html"/> and <see cref="ContentDirectory"/>.</summary>
     public Uri? Url { get; set; }
 
@@ -100,6 +105,7 @@ public sealed class RynWindowOptions
             TitleBarStyle = TitleBarStyle,
             Transparent = Transparent,
             HardwareAcceleration = HardwareAcceleration,
+            CrossOriginIsolation = CrossOriginIsolation,
             Url = Url,
             Html = Html,
             ContentDirectory = ContentDirectory,

--- a/tests/Ryn.Core.Tests/LocalWebServerTests.cs
+++ b/tests/Ryn.Core.Tests/LocalWebServerTests.cs
@@ -181,6 +181,39 @@ public sealed class LocalWebServerTests : IAsyncLifetime
         resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
+    [Fact]
+    public async Task StaticResponse_OmitsCrossOriginIsolationHeaders_ByDefault()
+    {
+        var resp = await _client.GetAsync("/");
+
+        resp.Headers.Contains("Cross-Origin-Opener-Policy").Should().BeFalse();
+        resp.Headers.Contains("Cross-Origin-Embedder-Policy").Should().BeFalse();
+        resp.Headers.Contains("Cross-Origin-Resource-Policy").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StaticResponse_SendsCoopCoepCorp_WhenCrossOriginIsolationEnabled()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"ryn-coi-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        await File.WriteAllTextAsync(Path.Combine(dir, "index.html"), "<html>COI</html>");
+
+        var host = new FakeHost();
+        await using var server = new LocalWebServer(dir, preferredPort: 28930, crossOriginIsolation: true);
+        server.SetWebView(host);
+        await server.StartAsync();
+        using var client = new HttpClient { BaseAddress = new Uri(server.Url) };
+
+        var resp = await client.GetAsync("/");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        resp.Headers.GetValues("Cross-Origin-Opener-Policy").Should().ContainSingle().Which.Should().Be("same-origin");
+        resp.Headers.GetValues("Cross-Origin-Embedder-Policy").Should().ContainSingle().Which.Should().Be("require-corp");
+        resp.Headers.GetValues("Cross-Origin-Resource-Policy").Should().ContainSingle().Which.Should().Be("same-origin");
+
+        try { Directory.Delete(dir, true); } catch (IOException) { }
+    }
+
     private sealed class FakeHost : ILocalServerHost
     {
         public string IpcToken { get; } = Guid.NewGuid().ToString("N");

--- a/tests/Ryn.Core.Tests/MultiWindowTests.cs
+++ b/tests/Ryn.Core.Tests/MultiWindowTests.cs
@@ -53,6 +53,7 @@ public sealed class MultiWindowTests
             DevTools = true,
             PersistWindowState = true,
             HardwareAcceleration = false,
+            CrossOriginIsolation = true,
         };
         options.AllowedOrigins.Add("https://allowed.test");
         options.CustomSchemes.Add("custom");
@@ -77,6 +78,7 @@ public sealed class MultiWindowTests
         projected.DevTools.Should().BeTrue();
         projected.PersistWindowState.Should().BeTrue();
         projected.HardwareAcceleration.Should().BeFalse();
+        projected.CrossOriginIsolation.Should().BeTrue();
         projected.AllowedOrigins.Should().ContainSingle().Which.Should().Be("https://allowed.test");
         projected.CustomSchemes.Should().ContainSingle().Which.Should().Be("custom");
         projected.BrowserFlags.Should().ContainSingle().Which.Should().Be("--enable-unsafe-webgpu");


### PR DESCRIPTION
Adds an opt-in that makes the page `crossOriginIsolated` so `SharedArrayBuffer` works — multithreaded WASM, multithreaded Blazor (targets v0.5.0).

- `CrossOriginIsolation` option on `RynOptions`/`RynWindowOptions` (default off), config-bound and projected to secondary windows
- When on, the ryn:// scheme handler and the local HTTP server emit `Cross-Origin-Opener-Policy`/`Embedder-Policy`/`Resource-Policy` on static responses
- Documents the secure-context requirement: reliable isolation needs the local-server path (http://localhost), since ryn:// may not be a secure context on WebKit
- Adds `docs/gpu-rendering.md` (rendering guide + the cross-origin-isolation section)
- Tests: COOP/COEP present-when-on / absent-by-default, and the option projection

Merge after #36 (v0.4.0). Touches a different region of `RynWindow.cs`, so it merges cleanly.