### PR TITLE
feat: add window click-through

### DIFF
--- a/src/Ryn.Core/IRynWindow.cs
+++ b/src/Ryn.Core/IRynWindow.cs
@@ -55,6 +55,10 @@ public interface IRynWindow
     public void SetFullscreen(bool fullscreen);
     /// <summary>Sets whether the window stays above other windows.</summary>
     public void SetAlwaysOnTop(bool alwaysOnTop);
+    /// <summary>Sets whether the window ignores mouse input, letting clicks fall through to whatever is
+    /// beneath it (for overlay/HUD-style windows). The page keeps running — timers, IPC and script still
+    /// work — it just receives no mouse events, so re-enabling input needs a non-mouse trigger.</summary>
+    public void SetClickThrough(bool clickThrough);
     /// <summary>Centers the window on its current screen.</summary>
     public void Center();
     /// <summary>

--- a/src/Ryn.Core/Internal/DeferredRynWindow.cs
+++ b/src/Ryn.Core/Internal/DeferredRynWindow.cs
@@ -61,6 +61,7 @@ internal sealed class DeferredRynWindow(RynWindowAccessor accessor) : IRynWindow
     public void Move(int x, int y) => Live.Move(x, y);
     public void SetFullscreen(bool fullscreen) => Live.SetFullscreen(fullscreen);
     public void SetAlwaysOnTop(bool alwaysOnTop) => Live.SetAlwaysOnTop(alwaysOnTop);
+    public void SetClickThrough(bool clickThrough) => Live.SetClickThrough(clickThrough);
     public void Center() => Live.Center();
     public void StartDrag() => Live.StartDrag();
     public void StartResize(WindowEdge edge) => Live.StartResize(edge);

--- a/src/Ryn.Core/RynOptions.cs
+++ b/src/Ryn.Core/RynOptions.cs
@@ -25,6 +25,7 @@ public sealed class RynOptions
     private bool _resizable = true;
     private TitleBarStyle _titleBarStyle = TitleBarStyle.Native;
     private bool _transparent;
+    private bool _clickThrough;
     private bool _hardwareAcceleration = true;
     private Uri? _url;
     private string? _html;
@@ -73,6 +74,11 @@ public sealed class RynOptions
 
     /// <summary>Whether the window background is transparent.</summary>
     public bool Transparent { get => _transparent; set => Set(ref _transparent, value); }
+
+    /// <summary>Whether the window ignores mouse input, letting clicks fall through to whatever is beneath it.
+    /// Combine with <see cref="Transparent"/>, a frameless <see cref="TitleBarStyle"/> and always-on-top for
+    /// overlay/HUD-style windows. Changeable at runtime via <see cref="IRynWindow.SetClickThrough"/>.</summary>
+    public bool ClickThrough { get => _clickThrough; set => Set(ref _clickThrough, value); }
 
     /// <summary>
     /// Whether the webview renders with GPU hardware acceleration. Default true (the engine's own default).

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -219,6 +219,9 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     public void SetAlwaysOnTop(bool alwaysOnTop) =>
         RunOnUi(() => { if (_window != null) Saucer.saucer_window_set_always_on_top(_window, (byte)(alwaysOnTop ? 1 : 0)); });
 
+    public void SetClickThrough(bool clickThrough) =>
+        RunOnUi(() => { if (_window != null) Saucer.saucer_window_set_click_through(_window, (byte)(clickThrough ? 1 : 0)); });
+
     public void Center() => RunOnUi(() =>
     {
         if (_window == null) return;
@@ -545,6 +548,8 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
             Saucer.saucer_window_set_background(_window, 0, 0, 0, 0);
             Saucer.saucer_webview_set_background(_webview, 0, 0, 0, 0);
         }
+        if (_options.ClickThrough)
+            Saucer.saucer_window_set_click_through(_window, 1);
         switch (_options.TitleBarStyle)
         {
             case TitleBarStyle.Hidden:

--- a/src/Ryn.Core/RynWindowOptions.cs
+++ b/src/Ryn.Core/RynWindowOptions.cs
@@ -38,6 +38,11 @@ public sealed class RynWindowOptions
     /// <summary>Whether the window background is transparent.</summary>
     public bool Transparent { get; set; }
 
+    /// <summary>Whether the window ignores mouse input, letting clicks fall through to whatever is beneath it.
+    /// Combine with <see cref="Transparent"/>, a frameless <see cref="TitleBarStyle"/> and always-on-top for
+    /// overlay/HUD-style windows. Changeable at runtime via <see cref="IRynWindow.SetClickThrough"/>.</summary>
+    public bool ClickThrough { get; set; }
+
     /// <summary>Whether the webview renders with GPU hardware acceleration (default true). Set false only as a
     /// compatibility escape hatch for flaky GPU drivers or headless/virtualized environments — it makes canvas,
     /// WebGL and WebGPU much slower. Applied once, before the webview is created.</summary>
@@ -104,6 +109,7 @@ public sealed class RynWindowOptions
             Resizable = Resizable,
             TitleBarStyle = TitleBarStyle,
             Transparent = Transparent,
+            ClickThrough = ClickThrough,
             HardwareAcceleration = HardwareAcceleration,
             CrossOriginIsolation = CrossOriginIsolation,
             Url = Url,

--- a/src/Ryn.Ipc/WindowCommands.cs
+++ b/src/Ryn.Ipc/WindowCommands.cs
@@ -52,6 +52,12 @@ internal sealed class WindowCommands
     [RynCommand("window.setAlwaysOnTop")]
     public void SetAlwaysOnTop(bool alwaysOnTop) => _windows.Current.SetAlwaysOnTop(alwaysOnTop);
 
+    /// <summary>Makes the calling window ignore mouse input (clicks fall through to what's beneath). The page
+    /// keeps running and can still invoke commands — it just gets no mouse events — so re-enabling input needs
+    /// a non-mouse trigger (a timer or event in this page, C#, or another window).</summary>
+    [RynCommand("window.setClickThrough")]
+    public void SetClickThrough(bool clickThrough) => _windows.Current.SetClickThrough(clickThrough);
+
     [RynCommand("window.center")]
     public void Center() => _windows.Current.Center();
 

--- a/tests/Ryn.Core.Tests/MultiWindowTests.cs
+++ b/tests/Ryn.Core.Tests/MultiWindowTests.cs
@@ -46,6 +46,7 @@ public sealed class MultiWindowTests
             Resizable = false,
             TitleBarStyle = TitleBarStyle.Hidden,
             Transparent = true,
+            ClickThrough = true,
             Url = new Uri("https://example.test/app"),
             UseLocalServer = true,
             LocalServerPort = 9001,
@@ -71,6 +72,7 @@ public sealed class MultiWindowTests
         projected.Resizable.Should().BeFalse();
         projected.TitleBarStyle.Should().Be(TitleBarStyle.Hidden);
         projected.Transparent.Should().BeTrue();
+        projected.ClickThrough.Should().BeTrue();
         projected.Url.Should().Be(new Uri("https://example.test/app"));
         projected.UseLocalServer.Should().BeTrue();
         projected.LocalServerPort.Should().Be(9001);

--- a/tests/Ryn.Core.Tests/RynOptionsTests.cs
+++ b/tests/Ryn.Core.Tests/RynOptionsTests.cs
@@ -17,6 +17,7 @@ public sealed class RynOptionsTests
         options.Resizable.Should().BeTrue();
         options.TitleBarStyle.Should().Be(TitleBarStyle.Native);
         options.Transparent.Should().BeFalse();
+        options.ClickThrough.Should().BeFalse();
         options.Url.Should().BeNull();
         options.DevTools.Should().BeFalse();
     }

--- a/tests/Ryn.Ipc.Tests/WindowCommandsTests.cs
+++ b/tests/Ryn.Ipc.Tests/WindowCommandsTests.cs
@@ -41,6 +41,18 @@ public sealed class WindowCommandsTests
     }
 
     [Fact]
+    public async Task SetClickThrough_ForwardsToCurrentWindow()
+    {
+        var (dispatcher, window) = BuildWindowDispatcher();
+
+        CurrentWindow.Value = window;
+        try { await dispatcher.DispatchAsync("window.setClickThrough", JsonArgs("{\"clickThrough\":true}")); }
+        finally { CurrentWindow.Value = null; }
+
+        window.Received(1).SetClickThrough(true);
+    }
+
+    [Fact]
     public async Task Center_ForwardsToCurrentWindow()
     {
         var (dispatcher, window) = BuildWindowDispatcher();


### PR DESCRIPTION
Adds window click-through for overlay/HUD-style apps (targets v0.6.0).

- `ClickThrough` on `RynOptions`/`RynWindowOptions`, applied in `ApplyWindowOptions` so overlays start click-through natively
- `SetClickThrough` on `IRynWindow`/`RynWindow`, backed by `saucer_window_set_click_through`, forwarded through `DeferredRynWindow`
- `window.setClickThrough` IPC command; a click-through page keeps running (timers, IPC), it just receives no mouse events
- Verified live on macOS: options path, JS IPC path and C# setter all read back the expected `NSWindow.ignoresMouseEvents` state
- Tests the options projection, defaults, and IPC dispatch through the generated router