### PR TITLE
feat: add per-pane user agent to webview panes

### DIFF
--- a/docs/webview-panes.md
+++ b/docs/webview-panes.md
@@ -37,7 +37,8 @@ const id = await window.__ryn.invoke('webviewPane.open', { options: {
   url: 'https://github.com',
   storagePath: '/path/to/session',   // per-pane cookie/storage dir (panes sharing a path share a session)
   devTools: false,
-  zoom: 1.0                          // 0.25–5.0
+  zoom: 1.0,                         // 0.25–5.0
+  userAgent: 'MyApp/1.0'             // custom UA for this pane (omit for the engine default)
 }});
 
 await window.__ryn.invoke('webviewPane.navigate',    { id, url: 'https://example.com' });
@@ -47,6 +48,7 @@ await window.__ryn.invoke('webviewPane.reload',      { id });
 await window.__ryn.invoke('webviewPane.setBounds',   { id, x: 0, y: 0, width: 800, height: 400 });
 await window.__ryn.invoke('webviewPane.setZoom',     { id, factor: 1.5 });
 await window.__ryn.invoke('webviewPane.setDevTools', { id, enabled: true });
+await window.__ryn.invoke('webviewPane.setUserAgent', { id, userAgent: 'MyApp/1.0' });
 await window.__ryn.invoke('webviewPane.execute',     { id, code: "window.scrollTo(0, 0)" }); // fire-and-forget
 const result = await window.__ryn.invoke('webviewPane.eval', { id, code: "document.title" }); // JSON result
 const url    = await window.__ryn.invoke('webviewPane.url',  { id });
@@ -94,6 +96,12 @@ responds (e.g. a syntax error in the expression) rejects after 10 seconds.
 navigation). On Windows and Linux it applies CSS zoom, re-applied automatically after
 each navigation; layout-affecting but universally supported.
 
+## Per-pane user agent
+
+`userAgent` at open time applies before the first navigation (`navigator.userAgent` in the
+pane reports it immediately). `setUserAgent` at runtime applies to subsequent navigations —
+immediately on macOS/Linux, on the next navigation on Windows — so reload after changing it.
+
 ## Per-pane sessions
 
 `storagePath` gives a pane its own cookie jar and storage, persisted across runs. Use one
@@ -104,7 +112,8 @@ should share a session. Omitting it uses the engine's default (shared) session.
 
 `WebViewPaneService` (singleton, resolvable from DI) exposes the same surface:
 `OpenAsync(PaneOpenRequest)`, `CloseAsync`, `SetBounds`, `Navigate`, `Back`, `Forward`,
-`Reload`, `SetZoom`, `SetDevTools`, `Execute`, `EvalAsync`, `GetUrl`, `List`, `CloseAll`.
+`Reload`, `SetZoom`, `SetDevTools`, `SetUserAgentAsync`, `Execute`, `EvalAsync`, `GetUrl`,
+`List`, `CloseAll`.
 
 ## Platform notes
 

--- a/src/Ryn.Plugins.WebViewPane/PaneEngineInterop.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneEngineInterop.cs
@@ -1,0 +1,175 @@
+using System.Runtime.InteropServices;
+using Ryn.Interop;
+
+namespace Ryn.Plugins.WebViewPane;
+
+/// <summary>
+/// Direct engine calls for pane features the saucer C ABI does not cover, built on the stable native
+/// handles saucer exposes (<c>saucer_webview_native</c>): WKWebView* on macOS, ICoreWebView2_2* on
+/// Windows (raw COM vtable calls — no built-in COM interop under NativeAOT), WebKitWebView* on Linux.
+/// All methods must be called on the UI thread with a live webview.
+/// </summary>
+internal static unsafe partial class PaneEngineInterop
+{
+    /// <summary>
+    /// Sets the pane's user agent for subsequent navigations. Applies immediately on macOS/Linux;
+    /// WebView2 applies it on the next navigation.
+    /// </summary>
+    public static void SetUserAgent(saucer_webview* webview, string userAgent)
+    {
+        var native = GetNativeHandle(webview);
+        if (native == 0)
+            throw new InvalidOperationException("The pane's native webview handle is unavailable.");
+
+        if (OperatingSystem.IsMacOS())
+        {
+            // WKWebView.customUserAgent = ua
+            var nsString = CreateNSString(userAgent);
+            objc_msgSend_ptr((void*)native, sel_registerName("setCustomUserAgent:"), (void*)nsString);
+        }
+        else if (OperatingSystem.IsWindows())
+        {
+            SetUserAgentWindows(native, userAgent);
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            var settings = webkit_web_view_get_settings(native);
+            if (settings == 0)
+                throw new InvalidOperationException("WebKitGTK settings are unavailable for this pane.");
+            webkit_settings_set_user_agent(settings, userAgent);
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("webviewPane.setUserAgent is not supported on this OS.");
+        }
+    }
+
+    /// <summary>Reads the first stable native pointer (idx 0) for a saucer webview; 0 if unavailable.</summary>
+    internal static nint GetNativeHandle(saucer_webview* webview)
+    {
+        nuint size = 0;
+        Saucer.saucer_webview_native(webview, 0, null, &size);
+        if (size < (nuint)sizeof(nint) || size > 64) return 0;
+        Span<byte> buf = stackalloc byte[(int)size];
+        fixed (byte* ptr = buf)
+        {
+            Saucer.saucer_webview_native(webview, 0, ptr, &size);
+            return MemoryMarshal.Read<nint>(buf);
+        }
+    }
+
+    // --- Windows: raw COM vtable calls against WebView2 ---
+    // Vtable slots verified against WebView2.h (SDK 1.0.2903.40); COM interface layouts are ABI-frozen.
+
+    private static readonly Guid IidCoreWebView2Settings2 = new("ee9a0f68-f46c-4e32-ac23-ef8cac224d2a");
+
+    private const int SlotQueryInterface = 0;
+    private const int SlotRelease = 2;
+    private const int SlotWebView2GetSettings = 3;   // ICoreWebView2::get_Settings
+    private const int SlotSettings2PutUserAgent = 22; // IUnknown(3) + ICoreWebView2Settings(18) + put_UserAgent(1)
+
+    // CA1508: the analyzer cannot model writes through out-pointers passed to native function pointers,
+    // so it thinks the post-call null checks are dead. They are not.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1508:Avoid dead conditional code",
+        Justification = "Out-params are written by native COM calls the analyzer cannot see.")]
+    private static void SetUserAgentWindows(nint coreWebView2, string userAgent)
+    {
+        // ICoreWebView2::get_Settings — the ICoreWebView2_2* saucer hands out derives from ICoreWebView2.
+        var getSettings = (delegate* unmanaged[Stdcall]<nint, nint*, int>)(*(nint**)coreWebView2)[SlotWebView2GetSettings];
+        nint settings = 0;
+        if (getSettings(coreWebView2, &settings) < 0 || settings == 0)
+            throw new InvalidOperationException("Failed to read WebView2 settings.");
+
+        try
+        {
+            var iid = IidCoreWebView2Settings2;
+            var queryInterface = (delegate* unmanaged[Stdcall]<nint, Guid*, nint*, int>)(*(nint**)settings)[SlotQueryInterface];
+            nint settings2 = 0;
+            if (queryInterface(settings, &iid, &settings2) < 0 || settings2 == 0)
+                throw new PlatformNotSupportedException(
+                    "This WebView2 runtime does not support user-agent overrides (ICoreWebView2Settings2).");
+
+            try
+            {
+                var putUserAgent = (delegate* unmanaged[Stdcall]<nint, char*, int>)(*(nint**)settings2)[SlotSettings2PutUserAgent];
+                int hr;
+                fixed (char* ua = userAgent)
+                {
+                    hr = putUserAgent(settings2, ua);
+                }
+                if (hr < 0)
+                    throw new InvalidOperationException($"WebView2 rejected the user agent (HRESULT 0x{hr:X8}).");
+            }
+            finally
+            {
+                ComRelease(settings2);
+            }
+        }
+        finally
+        {
+            ComRelease(settings);
+        }
+    }
+
+    internal static void ComRelease(nint unknown)
+    {
+        var release = (delegate* unmanaged[Stdcall]<nint, uint>)(*(nint**)unknown)[SlotRelease];
+        _ = release(unknown);
+    }
+
+    // --- macOS: ObjC runtime ---
+
+    internal static nint CreateNSString(string value)
+    {
+        // Autoreleased; safe on the UI thread where AppKit's run loop drains the pool.
+        return objc_msgSend_nint_str(objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), value);
+    }
+
+    [LibraryImport("libobjc.dylib")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static partial nint sel_registerName([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+    [LibraryImport("libobjc.dylib")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static partial nint objc_getClass([MarshalAs(UnmanagedType.LPUTF8Str)] string name);
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static partial void objc_msgSend_ptr(void* receiver, nint selector, void* arg);
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static partial nint objc_msgSend_nint_str(nint receiver, nint selector,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string arg);
+
+    // --- Linux: WebKitGTK ---
+    // saucer 8 builds against GTK4/libadwaita (WebKitGTK 6.0 API); older 4.1 kept as a fallback so a
+    // saucer built against webkit2gtk-4.1 still resolves.
+
+    static PaneEngineInterop()
+    {
+        if (OperatingSystem.IsLinux())
+            NativeLibrary.SetDllImportResolver(typeof(PaneEngineInterop).Assembly, ResolveLinuxLibrary);
+    }
+
+    private static nint ResolveLinuxLibrary(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        if (libraryName != "webkitgtk") return 0;
+        foreach (var candidate in (string[])
+                 ["libwebkitgtk-6.0.so.4", "libwebkitgtk-6.0.so", "libwebkit2gtk-4.1.so.0", "libwebkit2gtk-4.1.so"])
+        {
+            if (NativeLibrary.TryLoad(candidate, out var handle))
+                return handle;
+        }
+        return 0;
+    }
+
+    [LibraryImport("webkitgtk")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static partial nint webkit_web_view_get_settings(nint webView);
+
+    [LibraryImport("webkitgtk")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static partial void webkit_settings_set_user_agent(nint settings,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string userAgent);
+}

--- a/src/Ryn.Plugins.WebViewPane/PaneModels.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneModels.cs
@@ -25,6 +25,11 @@ public sealed class PaneOpenRequest
     /// <summary>Enable the engine's DevTools for this pane.</summary>
     public bool DevTools { get; set; }
 
+    /// <summary>
+    /// Custom user agent for this pane, applied before the first navigation. Omit for the engine default.
+    /// </summary>
+    public string? UserAgent { get; set; }
+
     /// <summary>Initial zoom factor (1.0 = 100%). Clamped to 0.25–5.0.</summary>
     public double Zoom { get; set; } = 1.0;
 }

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
@@ -45,6 +45,9 @@ internal sealed class WebViewPaneCommands
     [RynCommand("webviewPane.setDevTools")]
     public void SetDevTools(int id, bool enabled) => _service.SetDevTools(id, enabled);
 
+    [RynCommand("webviewPane.setUserAgent")]
+    public Task SetUserAgentAsync(int id, string userAgent) => _service.SetUserAgentAsync(id, userAgent);
+
     [RynCommand("webviewPane.execute")]
     public void Execute(int id, string code) => _service.Execute(id, code);
 

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
@@ -94,6 +94,11 @@ public sealed partial class WebViewPaneService : IDisposable
         if (windowHandle == 0) return -1;
 
         var opts = Saucer.saucer_webview_options_new((saucer_window*)windowHandle);
+        if (!string.IsNullOrEmpty(request.UserAgent))
+        {
+            fixed (byte* p = Utf8z(request.UserAgent))
+                Saucer.saucer_webview_options_set_user_agent(opts, (sbyte*)p);
+        }
         if (!string.IsNullOrEmpty(request.StoragePath))
         {
             Directory.CreateDirectory(request.StoragePath);
@@ -234,6 +239,41 @@ public sealed partial class WebViewPaneService : IDisposable
             ApplyZoomOnUi(state);
         });
     }
+
+    /// <summary>
+    /// Overrides the pane's user agent for subsequent navigations. Applies immediately on macOS/Linux;
+    /// WebView2 picks it up on the next navigation (reload to see it take effect).
+    /// </summary>
+    public async Task SetUserAgentAsync(int id, string userAgent)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(userAgent);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        PaneState? state;
+        lock (_lock)
+        {
+            _panes.TryGetValue(id, out state);
+        }
+        if (state is null) throw new ArgumentException($"Unknown pane id {id}.", nameof(id));
+
+        Exception? failure = null;
+        await _mainThread.InvokeAsync(() =>
+        {
+            try
+            {
+                if (state.Webview != 0)
+                    SetUserAgentOnUi(state.Webview, userAgent);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                failure = ex;
+            }
+        }).ConfigureAwait(false);
+        if (failure is not null) throw failure;
+    }
+
+    private static unsafe void SetUserAgentOnUi(nint webview, string userAgent) =>
+        PaneEngineInterop.SetUserAgent((saucer_webview*)webview, userAgent);
 
     /// <summary>Runs JavaScript in the pane, fire-and-forget.</summary>
     public void Execute(int id, string code)

--- a/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
+++ b/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
@@ -59,7 +59,7 @@ public sealed class WebViewPaneRequestTests
     public void PaneOpenRequest_DeserializesCamelCase_WithDefaults()
     {
         var request = JsonSerializer.Deserialize(
-            """{"x":10,"y":20,"width":640,"height":480,"url":"https://example.com","storagePath":"/tmp/pane","devTools":true,"zoom":1.5}""",
+            """{"x":10,"y":20,"width":640,"height":480,"url":"https://example.com","storagePath":"/tmp/pane","devTools":true,"zoom":1.5,"userAgent":"CoveBot/2.0"}""",
             WebViewPaneJsonContext.Default.PaneOpenRequest)!;
 
         request.X.Should().Be(10);
@@ -70,6 +70,7 @@ public sealed class WebViewPaneRequestTests
         request.StoragePath.Should().Be("/tmp/pane");
         request.DevTools.Should().BeTrue();
         request.Zoom.Should().Be(1.5);
+        request.UserAgent.Should().Be("CoveBot/2.0");
 
         var defaults = JsonSerializer.Deserialize("{}", WebViewPaneJsonContext.Default.PaneOpenRequest)!;
         defaults.Width.Should().Be(400);
@@ -77,6 +78,7 @@ public sealed class WebViewPaneRequestTests
         defaults.Zoom.Should().Be(1.0);
         defaults.Url.Should().BeNull();
         defaults.DevTools.Should().BeFalse();
+        defaults.UserAgent.Should().BeNull();
     }
 
     [Fact]
@@ -124,6 +126,8 @@ public sealed class WebViewPaneDependencyInjectionTests
         service.Invoking(s => s.CloseAll()).Should().NotThrow();
         (await service.CloseAsync(99)).Should().BeFalse();
         await service.Awaiting(s => s.EvalAsync(99, "1+1")).Should().ThrowAsync<ArgumentException>();
+        await service.Awaiting(s => s.SetUserAgentAsync(99, "UA/1.0")).Should().ThrowAsync<ArgumentException>();
+        await service.Awaiting(s => s.SetUserAgentAsync(1, "")).Should().ThrowAsync<ArgumentException>();
     }
 
     private sealed class NoopDispatcher : IMainThreadDispatcher


### PR DESCRIPTION
- `PaneOpenRequest.UserAgent` applied via saucer webview options before first navigation
- `webviewPane.setUserAgent` command + `SetUserAgentAsync` for runtime overrides
- Per-engine runtime setters: WKWebView `customUserAgent`, `ICoreWebView2Settings2::put_UserAgent` (raw COM vtables, AOT-safe), `webkit_settings_set_user_agent` (GTK 6.0 with 4.1 fallback)
- Docs + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCHwBNFMx7my96k3rSwidW