### PR TITLE
feat: add find-in-page to webview panes

### DIFF
--- a/docs/webview-panes.md
+++ b/docs/webview-panes.md
@@ -51,6 +51,11 @@ await window.__ryn.invoke('webviewPane.setDevTools', { id, enabled: true });
 await window.__ryn.invoke('webviewPane.setUserAgent', { id, userAgent: 'MyApp/1.0' });
 await window.__ryn.invoke('webviewPane.execute',     { id, code: "window.scrollTo(0, 0)" }); // fire-and-forget
 const result = await window.__ryn.invoke('webviewPane.eval', { id, code: "document.title" }); // JSON result
+
+// Find in page — all three return { matches, activeIndex } (activeIndex is 0-based, -1 = none)
+const hit = await window.__ryn.invoke('webviewPane.find',     { id, text: 'saucer', matchCase: false });
+await window.__ryn.invoke('webviewPane.findNext', { id, forward: true });   // wraps at the ends
+await window.__ryn.invoke('webviewPane.findStop', { id, clearHighlights: true });
 const url    = await window.__ryn.invoke('webviewPane.url',  { id });
 const ids    = await window.__ryn.invoke('webviewPane.list');
 await window.__ryn.invoke('webviewPane.close', { id });
@@ -102,6 +107,16 @@ responds (e.g. a syntax error in the expression) rejects after 10 seconds.
 navigation). On Windows and Linux it applies CSS zoom, re-applied automatically after
 each navigation; layout-affecting but universally supported.
 
+## Find in page
+
+`find` starts a session and scrolls the first match into view; `findNext` cycles (wrapping);
+`findStop` clears. The engine is injected JavaScript shared by all three platforms: matches are
+counted per text node and painted with the **CSS Custom Highlight API** (no DOM mutation). On
+engines without `CSS.highlights` (WebKit before Safari 17.2) counting, cycling, and scrolling
+still work — only the visual highlight is missing. Sessions are page-scoped: a navigation clears
+them, and matches spanning element boundaries (`ab<b>cd</b>`) are not found. Searching an empty
+string returns `{ matches: 0, activeIndex: -1 }` without error.
+
 ## Permission prompts
 
 When a page in a pane asks for a sensitive capability (getUserMedia, geolocation, …) the
@@ -128,8 +143,8 @@ should share a session. Omitting it uses the engine's default (shared) session.
 
 `WebViewPaneService` (singleton, resolvable from DI) exposes the same surface:
 `OpenAsync(PaneOpenRequest)`, `CloseAsync`, `SetBounds`, `Navigate`, `Back`, `Forward`,
-`Reload`, `SetZoom`, `SetDevTools`, `SetUserAgentAsync`, `Execute`, `EvalAsync`, `GetUrl`,
-`List`, `CloseAll`.
+`Reload`, `SetZoom`, `SetDevTools`, `SetUserAgentAsync`, `FindAsync`, `FindNextAsync`,
+`FindStopAsync`, `ResolvePermissionAsync`, `Execute`, `EvalAsync`, `GetUrl`, `List`, `CloseAll`.
 
 ## Platform notes
 

--- a/src/Ryn.Plugins.WebViewPane/PaneFindScript.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneFindScript.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+
+namespace Ryn.Plugins.WebViewPane;
+
+/// <summary>
+/// Builds the injected find-in-page engine. The engine runs identically on all three webview engines:
+/// it walks text nodes for matches and paints them with the CSS Custom Highlight API — no DOM mutation,
+/// no reliance on engine-specific native find APIs. On engines without CSS.highlights (WebKit before
+/// Safari 17.2) match counting, cycling, and scroll-to-match still work; only the visual highlight is
+/// absent. State lives in the page, so a navigation clears the session (re-issue find after load).
+/// </summary>
+internal static class PaneFindScript
+{
+    /// <summary>
+    /// The engine, installed once per document as <c>window.__rynFind</c>. Kept to same-text-node
+    /// matches — a match spanning element boundaries (e.g. across a <c>&lt;b&gt;</c> split) is not found,
+    /// which matches the behavior of simple finders. Hidden elements are filtered via getClientRects.
+    /// </summary>
+    private const string Engine =
+        """
+        window.__rynFind = (() => {
+          const NAME = 'ryn-find', ACTIVE = 'ryn-find-active';
+          let matches = [], active = -1, styleEl = null;
+          const supported = typeof Highlight !== 'undefined' && !!CSS.highlights;
+          const ensureStyle = () => {
+            if (styleEl || !supported) return;
+            styleEl = document.createElement('style');
+            styleEl.textContent =
+              '::highlight(ryn-find){background-color:#ffdd57;color:#000}' +
+              '::highlight(ryn-find-active){background-color:#ff8c1a;color:#000}';
+            document.documentElement.appendChild(styleEl);
+          };
+          const collect = (text, matchCase) => {
+            const ranges = [];
+            const needle = matchCase ? text : text.toLowerCase();
+            const root = document.body || document.documentElement;
+            if (!root) return ranges;
+            const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+              acceptNode(node) {
+                const p = node.parentElement;
+                if (!p) return NodeFilter.FILTER_REJECT;
+                const tag = p.tagName;
+                if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'NOSCRIPT' || tag === 'TEMPLATE')
+                  return NodeFilter.FILTER_REJECT;
+                if (p.getClientRects().length === 0)
+                  return NodeFilter.FILTER_REJECT;
+                return NodeFilter.FILTER_ACCEPT;
+              }
+            });
+            let node;
+            while ((node = walker.nextNode())) {
+              const hay = matchCase ? node.data : node.data.toLowerCase();
+              let i = 0;
+              while ((i = hay.indexOf(needle, i)) !== -1) {
+                const r = new Range();
+                r.setStart(node, i);
+                r.setEnd(node, i + text.length);
+                ranges.push(r);
+                i += text.length;
+              }
+            }
+            return ranges;
+          };
+          const paint = () => {
+            if (!supported) return;
+            CSS.highlights.set(NAME, new Highlight(...matches));
+            if (active >= 0) CSS.highlights.set(ACTIVE, new Highlight(matches[active]));
+            else CSS.highlights.delete(ACTIVE);
+          };
+          const reveal = () => {
+            if (active < 0) return;
+            const el = matches[active].startContainer.parentElement;
+            if (el && el.scrollIntoView) el.scrollIntoView({ block: 'center', inline: 'nearest' });
+          };
+          const result = () => ({ matches: matches.length, activeIndex: active });
+          return {
+            find(text, forward, matchCase) {
+              this.stop(true);
+              if (!text) return result();
+              matches = collect(String(text), !!matchCase);
+              active = matches.length === 0 ? -1 : (forward === false ? matches.length - 1 : 0);
+              ensureStyle();
+              paint();
+              reveal();
+              return result();
+            },
+            next(forward) {
+              if (matches.length === 0) return result();
+              active = forward === false
+                ? (active - 1 + matches.length) % matches.length
+                : (active + 1) % matches.length;
+              paint();
+              reveal();
+              return result();
+            },
+            stop(clearHighlights) {
+              if (clearHighlights !== false && supported) {
+                CSS.highlights.delete(NAME);
+                CSS.highlights.delete(ACTIVE);
+              }
+              matches = [];
+              active = -1;
+              return { matches: 0, activeIndex: -1 };
+            }
+          };
+        })();
+        """;
+
+    internal static string BuildFind(string text, bool forward, bool matchCase)
+    {
+        var textLiteral = JsonSerializer.Serialize(text, WebViewPaneJsonContext.Default.String);
+        return
+            $$"""
+            (() => {
+              if (!window.__rynFind) {
+            {{Engine}}
+              }
+              return window.__rynFind.find({{textLiteral}}, {{Js(forward)}}, {{Js(matchCase)}});
+            })()
+            """;
+    }
+
+    internal static string BuildNext(bool forward) =>
+        $"(() => window.__rynFind ? window.__rynFind.next({Js(forward)}) : ({{ matches: 0, activeIndex: -1 }}))()";
+
+    internal static string BuildStop(bool clearHighlights) =>
+        $"(() => window.__rynFind ? window.__rynFind.stop({Js(clearHighlights)}) : ({{ matches: 0, activeIndex: -1 }}))()";
+
+    private static string Js(bool value) => value ? "true" : "false";
+}

--- a/src/Ryn.Plugins.WebViewPane/PaneModels.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneModels.cs
@@ -54,6 +54,9 @@ internal sealed record PaneClosedEvent(int Id);
 /// </summary>
 internal sealed record PanePermissionEvent(int Id, long RequestId, string[] Kinds, string Url);
 
+/// <summary>ActiveIndex is 0-based; -1 when there are no matches (or the session was stopped).</summary>
+public sealed record PaneFindResult(int Matches, int ActiveIndex);
+
 [JsonSerializable(typeof(string))]
 [JsonSerializable(typeof(PaneOpenRequest))]
 [JsonSerializable(typeof(PaneNavigatedEvent))]
@@ -63,5 +66,6 @@ internal sealed record PanePermissionEvent(int Id, long RequestId, string[] Kind
 [JsonSerializable(typeof(PaneFaviconEvent))]
 [JsonSerializable(typeof(PaneClosedEvent))]
 [JsonSerializable(typeof(PanePermissionEvent))]
+[JsonSerializable(typeof(PaneFindResult))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class WebViewPaneJsonContext : JsonSerializerContext { }

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
@@ -45,6 +45,18 @@ internal sealed class WebViewPaneCommands
     [RynCommand("webviewPane.setDevTools")]
     public void SetDevTools(int id, bool enabled) => _service.SetDevTools(id, enabled);
 
+    [RynCommand("webviewPane.find")]
+    public Task<PaneFindResult> FindAsync(int id, string text, bool? forward, bool? matchCase) =>
+        _service.FindAsync(id, text, forward ?? true, matchCase ?? false);
+
+    [RynCommand("webviewPane.findNext")]
+    public Task<PaneFindResult> FindNextAsync(int id, bool? forward) =>
+        _service.FindNextAsync(id, forward ?? true);
+
+    [RynCommand("webviewPane.findStop")]
+    public Task<PaneFindResult> FindStopAsync(int id, bool? clearHighlights) =>
+        _service.FindStopAsync(id, clearHighlights ?? true);
+
     [RynCommand("webviewPane.resolvePermission")]
     public Task<bool> ResolvePermissionAsync(long requestId, bool grant) =>
         _service.ResolvePermissionAsync(requestId, grant);

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
@@ -352,6 +352,32 @@ public sealed partial class WebViewPaneService : IDisposable
         }
     }
 
+    /// <summary>
+    /// Starts (or restarts) a find session in the pane and returns the match count with the active
+    /// match scrolled into view. Matches are painted with the CSS Custom Highlight API where the
+    /// engine supports it; a navigation clears the session.
+    /// </summary>
+    public Task<PaneFindResult> FindAsync(int id, string text, bool forward = true, bool matchCase = false)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return RunFindAsync(id, PaneFindScript.BuildFind(text, forward, matchCase));
+    }
+
+    /// <summary>Moves the active match forward/backward, wrapping at the ends.</summary>
+    public Task<PaneFindResult> FindNextAsync(int id, bool forward = true) =>
+        RunFindAsync(id, PaneFindScript.BuildNext(forward));
+
+    /// <summary>Ends the find session, clearing highlights unless told to keep them.</summary>
+    public Task<PaneFindResult> FindStopAsync(int id, bool clearHighlights = true) =>
+        RunFindAsync(id, PaneFindScript.BuildStop(clearHighlights));
+
+    private async Task<PaneFindResult> RunFindAsync(int id, string expression)
+    {
+        var payload = await EvalAsync(id, expression).ConfigureAwait(false);
+        return JsonSerializer.Deserialize(payload, WebViewPaneJsonContext.Default.PaneFindResult)
+               ?? new PaneFindResult(0, -1);
+    }
+
     /// <summary>The pane's current URL as last reported by navigation events.</summary>
     public string GetUrl(int id)
     {

--- a/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
+++ b/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
@@ -93,6 +93,44 @@ public sealed class WebViewPaneRequestTests
     }
 }
 
+public sealed class WebViewPaneFindTests
+{
+    [Fact]
+    public void BuildFind_EscapesTextAndInstallsEngineOnce()
+    {
+        var script = PaneFindScript.BuildFind("he said \"hi\"\n<b>", forward: true, matchCase: false);
+
+        script.Should().Contain("if (!window.__rynFind)");
+        script.Should().Contain("window.__rynFind = (() => {");
+        // The needle is embedded as a JSON string literal — quotes, newlines, and HTML-sensitive
+        // characters are escaped by STJ's default encoder (" for '"', < for '<').
+        script.Should().Contain("he said \\u0022hi\\u0022\\n\\u003Cb\\u003E");
+        script.Should().Contain(".find(");
+        script.Should().Contain("true, false");
+        script.Should().NotContain("eval(");
+    }
+
+    [Fact]
+    public void BuildNextAndStop_GuardAgainstMissingEngine()
+    {
+        PaneFindScript.BuildNext(forward: false).Should().Contain("window.__rynFind ? window.__rynFind.next(false)");
+        PaneFindScript.BuildStop(clearHighlights: true).Should().Contain("window.__rynFind.stop(true)");
+        PaneFindScript.BuildNext(forward: true).Should().Contain("({ matches: 0, activeIndex: -1 })");
+    }
+
+    [Fact]
+    public void PaneFindResult_RoundTripsCamelCase()
+    {
+        var parsed = JsonSerializer.Deserialize(
+            """{"matches":12,"activeIndex":3}""", WebViewPaneJsonContext.Default.PaneFindResult)!;
+        parsed.Matches.Should().Be(12);
+        parsed.ActiveIndex.Should().Be(3);
+
+        JsonSerializer.Serialize(new PaneFindResult(0, -1), WebViewPaneJsonContext.Default.PaneFindResult)
+            .Should().Be("""{"matches":0,"activeIndex":-1}""");
+    }
+}
+
 public sealed class WebViewPanePermissionTests
 {
     [Theory]


### PR DESCRIPTION
- `webviewPane.find { id, text, forward?, matchCase? }` → `{ matches, activeIndex }`, plus `findNext`/`findStop`
- Injected engine shared by all three platforms: TreeWalker match collection + CSS Custom Highlight API (no DOM mutation), scroll-to-match, wrap-around cycling
- Graceful degradation where `CSS.highlights` is unavailable (counting/cycling/scrolling still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCHwBNFMx7my96k3rSwidW