### PR TITLE
feat: add pane screenshots and fix close crash on macOS

### DIFF
--- a/docs/webview-panes.md
+++ b/docs/webview-panes.md
@@ -52,6 +52,10 @@ await window.__ryn.invoke('webviewPane.setUserAgent', { id, userAgent: 'MyApp/1.
 await window.__ryn.invoke('webviewPane.execute',     { id, code: "window.scrollTo(0, 0)" }); // fire-and-forget
 const result = await window.__ryn.invoke('webviewPane.eval', { id, code: "document.title" }); // JSON result
 
+// Screenshot — base64 PNG of the visible pane rect at device-pixel scale
+const b64 = await window.__ryn.invoke('webviewPane.screenshot', { id });
+// e.g. img.src = 'data:image/png;base64,' + b64;
+
 // Find in page — all three return { matches, activeIndex } (activeIndex is 0-based, -1 = none)
 const hit = await window.__ryn.invoke('webviewPane.find',     { id, text: 'saucer', matchCase: false });
 await window.__ryn.invoke('webviewPane.findNext', { id, forward: true });   // wraps at the ends
@@ -107,6 +111,14 @@ responds (e.g. a syntax error in the expression) rejects after 10 seconds.
 navigation). On Windows and Linux it applies CSS zoom, re-applied automatically after
 each navigation; layout-affecting but universally supported.
 
+## Screenshots
+
+`screenshot` captures the pane's **visible viewport** as a PNG via the engine's native
+snapshot API (`WKWebView.takeSnapshot`, `CapturePreview`, `webkit_web_view_get_snapshot`)
+at device-pixel scale, returned as a base64 string. It works while the pane is partially
+occluded by sibling panes, and errors (rather than hangs) on a crashed pane — the call
+also times out after 15 seconds as a backstop.
+
 ## Find in page
 
 `find` starts a session and scrolls the first match into view; `findNext` cycles (wrapping);
@@ -143,8 +155,9 @@ should share a session. Omitting it uses the engine's default (shared) session.
 
 `WebViewPaneService` (singleton, resolvable from DI) exposes the same surface:
 `OpenAsync(PaneOpenRequest)`, `CloseAsync`, `SetBounds`, `Navigate`, `Back`, `Forward`,
-`Reload`, `SetZoom`, `SetDevTools`, `SetUserAgentAsync`, `FindAsync`, `FindNextAsync`,
-`FindStopAsync`, `ResolvePermissionAsync`, `Execute`, `EvalAsync`, `GetUrl`, `List`, `CloseAll`.
+`Reload`, `SetZoom`, `SetDevTools`, `SetUserAgentAsync`, `ScreenshotAsync`, `FindAsync`,
+`FindNextAsync`, `FindStopAsync`, `ResolvePermissionAsync`, `Execute`, `EvalAsync`, `GetUrl`,
+`List`, `CloseAll`.
 
 ## Platform notes
 

--- a/src/Ryn.Plugins.WebViewPane/Native/ComCallback.cs
+++ b/src/Ryn.Plugins.WebViewPane/Native/ComCallback.cs
@@ -1,0 +1,95 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace Ryn.Plugins.WebViewPane.Native;
+
+/// <summary>
+/// Factory for C#-implemented single-method COM objects (WebView2 completed/event handlers) under
+/// NativeAOT, where built-in COM interop is unavailable. Each instance is one unmanaged allocation
+/// holding the object header, a 4-slot vtable (QueryInterface/AddRef/Release/Invoke), and a GCHandle
+/// to a managed callback. Reference counting is real: the final Release frees the GCHandle and the
+/// allocation, so handlers survive as long as WebView2 holds them.
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal static unsafe class ComCallback
+{
+    private const int HrOk = 0;
+    private const int HrNoInterface = unchecked((int)0x80004002);
+    private static readonly Guid IidUnknown = new("00000000-0000-0000-C000-000000000046");
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Instance
+    {
+        public nint Vtbl;      // points at Slots, below
+        public int RefCount;
+        public Guid Iid;       // the single handler interface this object implements
+        public nint Callback;  // GCHandle to the managed invoke delegate
+        // followed in memory by: nint Slots[4]
+    }
+
+    /// <summary>
+    /// Creates a COM object with refcount 1. <paramref name="invoke"/> is an
+    /// <c>[UnmanagedCallersOnly]</c> pointer with the handler's Invoke signature (first arg: the COM
+    /// this-pointer); recover the managed callback inside it via <see cref="GetCallback{T}"/>.
+    /// Release with <see cref="Release"/> after handing it to WebView2 (which AddRefs it).
+    /// </summary>
+    public static nint Create(Guid iid, nint invoke, object callback)
+    {
+        var memory = Marshal.AllocHGlobal(sizeof(Instance) + 4 * sizeof(nint));
+        var instance = (Instance*)memory;
+        var slots = (nint*)(memory + sizeof(Instance));
+
+        slots[0] = (nint)(delegate* unmanaged[Stdcall]<nint, Guid*, nint*, int>)&QueryInterface;
+        slots[1] = (nint)(delegate* unmanaged[Stdcall]<nint, uint>)&AddRef;
+        slots[2] = (nint)(delegate* unmanaged[Stdcall]<nint, uint>)&ReleaseImpl;
+        slots[3] = invoke;
+
+        instance->Vtbl = (nint)slots;
+        instance->RefCount = 1;
+        instance->Iid = iid;
+        instance->Callback = GCHandle.ToIntPtr(GCHandle.Alloc(callback));
+        return memory;
+    }
+
+    /// <summary>Reads the managed callback from a COM this-pointer inside an Invoke callback.</summary>
+    public static T GetCallback<T>(nint comThis) where T : class =>
+        (T)GCHandle.FromIntPtr(((Instance*)comThis)->Callback).Target!;
+
+    public static void Release(nint comThis)
+    {
+        var release = (delegate* unmanaged[Stdcall]<nint, uint>)(*(nint**)comThis)[2];
+        _ = release(comThis);
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvStdcall)])]
+    private static int QueryInterface(nint comThis, Guid* riid, nint* ppv)
+    {
+        if (ppv == null) return HrNoInterface;
+        var instance = (Instance*)comThis;
+        if (*riid == IidUnknown || *riid == instance->Iid)
+        {
+            _ = Interlocked.Increment(ref instance->RefCount);
+            *ppv = comThis;
+            return HrOk;
+        }
+        *ppv = 0;
+        return HrNoInterface;
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvStdcall)])]
+    private static uint AddRef(nint comThis) =>
+        (uint)Interlocked.Increment(ref ((Instance*)comThis)->RefCount);
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvStdcall)])]
+    private static uint ReleaseImpl(nint comThis)
+    {
+        var instance = (Instance*)comThis;
+        var remaining = Interlocked.Decrement(ref instance->RefCount);
+        if (remaining == 0)
+        {
+            GCHandle.FromIntPtr(instance->Callback).Free();
+            Marshal.FreeHGlobal(comThis);
+        }
+        return (uint)remaining;
+    }
+}

--- a/src/Ryn.Plugins.WebViewPane/Native/MacBlocks.cs
+++ b/src/Ryn.Plugins.WebViewPane/Native/MacBlocks.cs
@@ -1,0 +1,64 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace Ryn.Plugins.WebViewPane.Native;
+
+/// <summary>
+/// Minimal Objective-C block support: builds a heap block literal whose invoke function is an
+/// <c>[UnmanagedCallersOnly]</c> static and whose single captured value is an opaque context pointer
+/// (typically a GCHandle). The block carries no copy/dispose helpers — the captured pointer is plain
+/// data, so the runtime's <c>Block_copy</c> byte-copy is correct. Callers free the literal after the
+/// consuming API returns (the API copies the block if it outlives the call).
+/// </summary>
+[SupportedOSPlatform("macos")]
+internal static unsafe class MacBlocks
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct BlockLiteral
+    {
+        public nint Isa;
+        public int Flags;
+        public int Reserved;
+        public nint Invoke;
+        public nint Descriptor;
+        public nint Context; // captured payload — first (and only) captured "variable"
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BlockDescriptor
+    {
+        public nuint Reserved;
+        public nuint Size;
+    }
+
+    private static readonly nint StackBlockIsa =
+        NativeLibrary.GetExport(NativeLibrary.Load("/usr/lib/libSystem.B.dylib"), "_NSConcreteStackBlock");
+
+    private static readonly nint SharedDescriptor = CreateDescriptor();
+
+    private static nint CreateDescriptor()
+    {
+        var descriptor = (BlockDescriptor*)Marshal.AllocHGlobal(sizeof(BlockDescriptor));
+        descriptor->Reserved = 0;
+        descriptor->Size = (nuint)sizeof(BlockLiteral);
+        return (nint)descriptor;
+    }
+
+    /// <summary>Builds a block. Free with <see cref="Free"/> once the consuming call has returned.</summary>
+    public static nint Create(nint invoke, nint context)
+    {
+        var block = (BlockLiteral*)Marshal.AllocHGlobal(sizeof(BlockLiteral));
+        block->Isa = StackBlockIsa;
+        block->Flags = 0;
+        block->Reserved = 0;
+        block->Invoke = invoke;
+        block->Descriptor = SharedDescriptor;
+        block->Context = context;
+        return (nint)block;
+    }
+
+    public static void Free(nint block) => Marshal.FreeHGlobal(block);
+
+    /// <summary>Reads the captured context pointer from inside an invoke callback.</summary>
+    public static nint GetContext(nint block) => ((BlockLiteral*)block)->Context;
+}

--- a/src/Ryn.Plugins.WebViewPane/PaneEngineInterop.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneEngineInterop.cs
@@ -154,9 +154,15 @@ internal static unsafe partial class PaneEngineInterop
 
     private static nint ResolveLinuxLibrary(string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath)
     {
-        if (libraryName != "webkitgtk") return 0;
-        foreach (var candidate in (string[])
-                 ["libwebkitgtk-6.0.so.4", "libwebkitgtk-6.0.so", "libwebkit2gtk-4.1.so.0", "libwebkit2gtk-4.1.so"])
+        string[] candidates = libraryName switch
+        {
+            "webkitgtk" => ["libwebkitgtk-6.0.so.4", "libwebkitgtk-6.0.so", "libwebkit2gtk-4.1.so.0", "libwebkit2gtk-4.1.so"],
+            "cairo" => ["libcairo.so.2", "libcairo.so"],
+            "glib" => ["libglib-2.0.so.0", "libglib-2.0.so"],
+            "gobject" => ["libgobject-2.0.so.0", "libgobject-2.0.so"],
+            _ => [],
+        };
+        foreach (var candidate in candidates)
         {
             if (NativeLibrary.TryLoad(candidate, out var handle))
                 return handle;

--- a/src/Ryn.Plugins.WebViewPane/PaneScreenshotInterop.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneScreenshotInterop.cs
@@ -1,0 +1,329 @@
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Ryn.Core.Internal;
+using Ryn.Interop;
+using Ryn.Plugins.WebViewPane.Native;
+
+namespace Ryn.Plugins.WebViewPane;
+
+/// <summary>
+/// Captures a PNG of a pane's visible viewport with the engine's native snapshot API:
+/// <c>WKWebView.takeSnapshot</c> (ObjC block completion), <c>ICoreWebView2.CapturePreview</c> into a
+/// memory IStream (COM completed-handler), and <c>webkit_web_view_get_snapshot</c> → cairo PNG.
+/// Start on the UI thread; the completion fires later on the engine's callback thread with either
+/// PNG bytes or an error message — never both, never neither.
+/// </summary>
+internal static unsafe partial class PaneScreenshotInterop
+{
+    internal sealed class Capture
+    {
+        public required Action<byte[]?, string?> Completion { get; init; }
+        public nint Stream; // Windows: IStream* being written by CapturePreview
+    }
+
+    public static void Start(saucer_webview* webview, Action<byte[]?, string?> completion)
+    {
+        var native = PaneEngineInterop.GetNativeHandle(webview);
+        if (native == 0)
+        {
+            completion(null, "The pane's native webview handle is unavailable.");
+            return;
+        }
+
+        if (OperatingSystem.IsMacOS()) StartMac(native, completion);
+        else if (OperatingSystem.IsWindows()) StartWindows(native, completion);
+        else if (OperatingSystem.IsLinux()) StartLinux(native, completion);
+        else completion(null, "webviewPane.screenshot is not supported on this OS.");
+    }
+
+    // --- macOS ---
+
+    [SupportedOSPlatform("macos")]
+    private static void StartMac(nint wkWebView, Action<byte[]?, string?> completion)
+    {
+        var context = GCHandle.Alloc(new Capture { Completion = completion });
+        var block = MacBlocks.Create(
+            (nint)(delegate* unmanaged[Cdecl]<nint, nint, nint, void>)&OnMacSnapshot,
+            GCHandle.ToIntPtr(context));
+        try
+        {
+            // takeSnapshotWithConfiguration:nil → visible viewport at device scale. WebKit copies the block.
+            objc_msgSend_2(wkWebView,
+                PaneEngineInterop.sel_registerName("takeSnapshotWithConfiguration:completionHandler:"), 0, block);
+        }
+        finally
+        {
+            MacBlocks.Free(block);
+        }
+    }
+
+    [SupportedOSPlatform("macos")]
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnMacSnapshot(nint block, nint nsImage, nint nsError)
+    {
+        var handle = GCHandle.FromIntPtr(MacBlocks.GetContext(block));
+        var capture = (Capture)handle.Target!;
+        handle.Free();
+
+        NativeGuard.Invoke("PaneScreenshotInterop.OnMacSnapshot", () =>
+        {
+            if (nsImage == 0)
+            {
+                capture.Completion(null, DescribeNSError(nsError));
+                return;
+            }
+            var png = EncodeNSImageAsPng(nsImage);
+            if (png is null) capture.Completion(null, "Failed to encode the snapshot as PNG.");
+            else capture.Completion(png, null);
+        });
+    }
+
+    [SupportedOSPlatform("macos")]
+    private static byte[]? EncodeNSImageAsPng(nint nsImage)
+    {
+        var sel = PaneEngineInterop.sel_registerName("CGImageForProposedRect:context:hints:");
+        var cgImage = objc_msgSend_3(nsImage, sel, 0, 0, 0);
+        if (cgImage == 0) return null;
+
+        var rep = objc_msgSend_1(
+            objc_msgSend_0(PaneEngineInterop.objc_getClass("NSBitmapImageRep"),
+                PaneEngineInterop.sel_registerName("alloc")),
+            PaneEngineInterop.sel_registerName("initWithCGImage:"), cgImage);
+        if (rep == 0) return null;
+
+        try
+        {
+            // NSBitmapImageFileTypePNG = 4; returns autoreleased NSData.
+            var data = objc_msgSend_nuint_ptr(rep,
+                PaneEngineInterop.sel_registerName("representationUsingType:properties:"), 4, 0);
+            if (data == 0) return null;
+
+            var bytes = objc_msgSend_0(data, PaneEngineInterop.sel_registerName("bytes"));
+            var length = (long)objc_msgSend_0(data, PaneEngineInterop.sel_registerName("length"));
+            if (bytes == 0 || length <= 0 || length > int.MaxValue) return null;
+
+            var result = new byte[length];
+            Marshal.Copy(bytes, result, 0, (int)length);
+            return result;
+        }
+        finally
+        {
+            _ = objc_msgSend_0(rep, PaneEngineInterop.sel_registerName("release"));
+        }
+    }
+
+    private static string DescribeNSError(nint nsError)
+    {
+        if (nsError == 0) return "The engine returned no snapshot.";
+        var description = objc_msgSend_0(nsError, PaneEngineInterop.sel_registerName("localizedDescription"));
+        if (description == 0) return "The engine returned no snapshot.";
+        var utf8 = objc_msgSend_0(description, PaneEngineInterop.sel_registerName("UTF8String"));
+        return utf8 == 0 ? "The engine returned no snapshot." : Marshal.PtrToStringUTF8(utf8) ?? "Snapshot failed.";
+    }
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial nint objc_msgSend_0(nint receiver, nint selector);
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial nint objc_msgSend_1(nint receiver, nint selector, nint arg1);
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial nint objc_msgSend_2(nint receiver, nint selector, nint arg1, nint arg2);
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial nint objc_msgSend_3(nint receiver, nint selector, nint arg1, nint arg2, nint arg3);
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial nint objc_msgSend_nuint_ptr(nint receiver, nint selector, nuint arg1, nint arg2);
+
+    // --- Windows ---
+
+    private static readonly Guid IidCapturePreviewCompletedHandler = new("697e05e9-3d8f-45fa-96f4-8ffe1ededaf5");
+    private const int SlotWebView2CapturePreview = 30; // ICoreWebView2::CapturePreview
+    private const int SlotStreamRead = 3;              // ISequentialStream::Read
+    private const int SlotStreamSeek = 5;              // IStream::Seek
+
+    [SupportedOSPlatform("windows")]
+    private static void StartWindows(nint coreWebView2, Action<byte[]?, string?> completion)
+    {
+        var stream = SHCreateMemStream(0, 0);
+        if (stream == 0)
+        {
+            completion(null, "Failed to allocate a capture stream.");
+            return;
+        }
+
+        var capture = new Capture { Completion = completion, Stream = stream };
+        var handler = ComCallback.Create(IidCapturePreviewCompletedHandler,
+            (nint)(delegate* unmanaged[Stdcall]<nint, int, int>)&OnWindowsCaptureCompleted, capture);
+
+        var capturePreview = (delegate* unmanaged[Stdcall]<nint, int, nint, nint, int>)
+            (*(nint**)coreWebView2)[SlotWebView2CapturePreview];
+        var hr = capturePreview(coreWebView2, 0 /* PNG */, stream, handler);
+        ComCallback.Release(handler); // WebView2 holds its own reference until Invoke
+
+        if (hr < 0)
+        {
+            PaneEngineInterop.ComRelease(stream);
+            completion(null, $"CapturePreview failed (HRESULT 0x{hr:X8}).");
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static int OnWindowsCaptureCompleted(nint comThis, int errorCode)
+    {
+        var capture = ComCallback.GetCallback<Capture>(comThis);
+        NativeGuard.Invoke("PaneScreenshotInterop.OnWindowsCaptureCompleted", () =>
+        {
+            var stream = capture.Stream;
+            try
+            {
+                if (errorCode < 0)
+                {
+                    capture.Completion(null, $"CapturePreview failed (HRESULT 0x{errorCode:X8}).");
+                    return;
+                }
+                var png = ReadStreamToEnd(stream);
+                if (png is null) capture.Completion(null, "Failed to read the capture stream.");
+                else capture.Completion(png, null);
+            }
+            finally
+            {
+                PaneEngineInterop.ComRelease(stream);
+            }
+        });
+        return 0;
+    }
+
+    // CA1508: `got` is written through a pointer by the native Read call; the analyzer cannot see it.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1508:Avoid dead conditional code",
+        Justification = "Out-params are written by native COM calls the analyzer cannot see.")]
+    [SupportedOSPlatform("windows")]
+    private static byte[]? ReadStreamToEnd(nint stream)
+    {
+        var vtbl = *(nint**)stream;
+        var seek = (delegate* unmanaged[Stdcall]<nint, long, uint, ulong*, int>)vtbl[SlotStreamSeek];
+        if (seek(stream, 0, 0 /* STREAM_SEEK_SET */, null) < 0) return null;
+
+        var read = (delegate* unmanaged[Stdcall]<nint, byte*, uint, uint*, int>)vtbl[SlotStreamRead];
+        using var buffer = new MemoryStream();
+        var chunk = new byte[64 * 1024];
+        while (true)
+        {
+            uint got = 0;
+            int hr;
+            fixed (byte* p = chunk)
+            {
+                hr = read(stream, p, (uint)chunk.Length, &got);
+            }
+            if (hr < 0) return null;
+            if (got == 0) break;
+            buffer.Write(chunk, 0, (int)got);
+            if (hr == 1 /* S_FALSE: end of stream */) break;
+        }
+        return buffer.ToArray();
+    }
+
+    [LibraryImport("shlwapi.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial nint SHCreateMemStream(nint pInit, uint cbInit);
+
+    // --- Linux ---
+
+    [SupportedOSPlatform("linux")]
+    private static void StartLinux(nint webKitWebView, Action<byte[]?, string?> completion)
+    {
+        var context = GCHandle.Alloc(new Capture { Completion = completion });
+        // WEBKIT_SNAPSHOT_REGION_VISIBLE = 0, WEBKIT_SNAPSHOT_OPTIONS_NONE = 0
+        webkit_web_view_get_snapshot(webKitWebView, 0, 0, 0,
+            (nint)(delegate* unmanaged[Cdecl]<nint, nint, nint, void>)&OnLinuxSnapshotReady,
+            GCHandle.ToIntPtr(context));
+    }
+
+    [SupportedOSPlatform("linux")]
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnLinuxSnapshotReady(nint sourceObject, nint asyncResult, nint userData)
+    {
+        var handle = GCHandle.FromIntPtr(userData);
+        var capture = (Capture)handle.Target!;
+        handle.Free();
+
+        NativeGuard.Invoke("PaneScreenshotInterop.OnLinuxSnapshotReady", () =>
+        {
+            nint error = 0;
+            var surface = webkit_web_view_get_snapshot_finish(sourceObject, asyncResult, &error);
+            if (surface == 0)
+            {
+                capture.Completion(null, DescribeGError(error));
+                return;
+            }
+            try
+            {
+                var path = Path.Combine(Path.GetTempPath(), $"ryn-pane-{Guid.NewGuid():N}.png");
+                try
+                {
+                    // CAIRO_STATUS_SUCCESS = 0
+                    if (cairo_surface_write_to_png(surface, path) != 0)
+                    {
+                        capture.Completion(null, "cairo failed to encode the snapshot as PNG.");
+                        return;
+                    }
+                    capture.Completion(File.ReadAllBytes(path), null);
+                }
+                finally
+                {
+                    try { File.Delete(path); } catch (IOException) { }
+                }
+            }
+            finally
+            {
+                cairo_surface_destroy(surface);
+            }
+        });
+    }
+
+    [SupportedOSPlatform("linux")]
+    private static string DescribeGError(nint error)
+    {
+        if (error == 0) return "The engine returned no snapshot.";
+        try
+        {
+            // GError layout: { GQuark domain (uint32 + pad); int code; char* message }
+            var message = Marshal.PtrToStringUTF8(*(nint*)(error + 8));
+            return string.IsNullOrEmpty(message) ? "The engine returned no snapshot." : message;
+        }
+        finally
+        {
+            g_error_free(error);
+        }
+    }
+
+    [LibraryImport("webkitgtk")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial void webkit_web_view_get_snapshot(nint webView, int region, int options,
+        nint cancellable, nint callback, nint userData);
+
+    [LibraryImport("webkitgtk")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial nint webkit_web_view_get_snapshot_finish(nint webView, nint result, nint* error);
+
+    [LibraryImport("cairo")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial int cairo_surface_write_to_png(nint surface,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string filename);
+
+    [LibraryImport("cairo")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial void cairo_surface_destroy(nint surface);
+
+    [LibraryImport("glib")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial void g_error_free(nint error);
+}

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
@@ -45,6 +45,9 @@ internal sealed class WebViewPaneCommands
     [RynCommand("webviewPane.setDevTools")]
     public void SetDevTools(int id, bool enabled) => _service.SetDevTools(id, enabled);
 
+    [RynCommand("webviewPane.screenshot")]
+    public Task<string> ScreenshotAsync(int id) => _service.ScreenshotAsync(id);
+
     [RynCommand("webviewPane.find")]
     public Task<PaneFindResult> FindAsync(int id, string text, bool? forward, bool? matchCase) =>
         _service.FindAsync(id, text, forward ?? true, matchCase ?? false);

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
@@ -201,8 +201,11 @@ public sealed partial class WebViewPaneService : IDisposable
         var webview = (saucer_webview*)state.Webview;
         if (webview != null)
         {
-            foreach (var evt in Enum.GetValues<saucer_webview_event>())
-                Saucer.saucer_webview_off_all(webview, evt);
+            // Do NOT saucer_webview_off_all before free: on macOS clearing the navigated/favicon
+            // listeners tears down saucer's KVO observers, and free then removes them again —
+            // NSRangeException ("not registered as an observer") and the app dies. free owns the
+            // full teardown; the GCHandle freed below is only read by callbacks, which cannot fire
+            // once the webview is gone.
             Saucer.saucer_webview_free(webview);
             state.Webview = 0;
         }
@@ -377,6 +380,57 @@ public sealed partial class WebViewPaneService : IDisposable
         return JsonSerializer.Deserialize(payload, WebViewPaneJsonContext.Default.PaneFindResult)
                ?? new PaneFindResult(0, -1);
     }
+
+    /// <summary>
+    /// Captures the pane's visible viewport as a PNG (device-pixel scale) and returns it base64-encoded.
+    /// Uses the engine's native snapshot API; throws on unknown panes, engine errors, and a 15s timeout
+    /// (a crashed pane errors rather than hangs).
+    /// </summary>
+    public async Task<string> ScreenshotAsync(int id)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        PaneState? state;
+        lock (_lock)
+        {
+            _panes.TryGetValue(id, out state);
+        }
+        if (state is null) throw new ArgumentException($"Unknown pane id {id}.", nameof(id));
+
+        var tcs = new TaskCompletionSource<byte[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await _mainThread.InvokeAsync(() =>
+        {
+            try
+            {
+                if (state.Webview == 0)
+                {
+                    tcs.TrySetException(new InvalidOperationException("The pane was closed."));
+                    return;
+                }
+                StartScreenshotOnUi(state.Webview, (bytes, error) =>
+                {
+                    if (bytes is not null) tcs.TrySetResult(bytes);
+                    else tcs.TrySetException(new InvalidOperationException(error ?? "Snapshot failed."));
+                });
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                tcs.TrySetException(ex);
+            }
+        }).ConfigureAwait(false);
+
+        try
+        {
+            var png = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(15)).ConfigureAwait(false);
+            return Convert.ToBase64String(png);
+        }
+        catch (TimeoutException)
+        {
+            throw new TimeoutException("webviewPane.screenshot did not complete within 15s.");
+        }
+    }
+
+    private static unsafe void StartScreenshotOnUi(nint webview, Action<byte[]?, string?> completion) =>
+        PaneScreenshotInterop.Start((saucer_webview*)webview, completion);
 
     /// <summary>The pane's current URL as last reported by navigation events.</summary>
     public string GetUrl(int id)

--- a/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
+++ b/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
@@ -196,6 +196,7 @@ public sealed class WebViewPaneDependencyInjectionTests
         await service.Awaiting(s => s.SetUserAgentAsync(99, "UA/1.0")).Should().ThrowAsync<ArgumentException>();
         await service.Awaiting(s => s.SetUserAgentAsync(1, "")).Should().ThrowAsync<ArgumentException>();
         (await service.ResolvePermissionAsync(12345, grant: true)).Should().BeFalse();
+        await service.Awaiting(s => s.ScreenshotAsync(99)).Should().ThrowAsync<ArgumentException>();
     }
 
     private sealed class NoopDispatcher : IMainThreadDispatcher


### PR DESCRIPTION
- `webviewPane.screenshot { id }` → base64 PNG (device-pixel scale) via native snapshot APIs on all three engines
- New AOT-safe infra: ObjC block helper (macOS) + refcounted COM handler factory (Windows) — reused by upcoming lifecycle/download/CDP work
- Fixes a pre-existing macOS crash on `webviewPane.close` (double KVO observer teardown in the off_all+free sequence)
- Verified live on macOS: open-time/runtime UA, find (count/cycle/case/stop), screenshot pixels, close — full probe pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCHwBNFMx7my96k3rSwidW