### PR TITLE
feat: add pane crash detection, recovery, and suspension

### DIFF
--- a/docs/webview-panes.md
+++ b/docs/webview-panes.md
@@ -49,6 +49,8 @@ await window.__ryn.invoke('webviewPane.setBounds',   { id, x: 0, y: 0, width: 80
 await window.__ryn.invoke('webviewPane.setZoom',     { id, factor: 1.5 });
 await window.__ryn.invoke('webviewPane.setDevTools', { id, enabled: true });
 await window.__ryn.invoke('webviewPane.setUserAgent', { id, userAgent: 'MyApp/1.0' });
+await window.__ryn.invoke('webviewPane.setSuspended', { id, suspended: true }); // hide + throttle
+await window.__ryn.invoke('webviewPane.reloadFromCrash', { id });               // after processTerminated
 await window.__ryn.invoke('webviewPane.execute',     { id, code: "window.scrollTo(0, 0)" }); // fire-and-forget
 const result = await window.__ryn.invoke('webviewPane.eval', { id, code: "document.title" }); // JSON result
 
@@ -74,6 +76,9 @@ window.__ryn.on('webviewPane.loadStateChanged', e => { /* { id, state: 'started'
 window.__ryn.on('webviewPane.domReady',         e => { /* { id } */ });
 window.__ryn.on('webviewPane.faviconChanged',   e => { /* { id, dataUrl } — base64 data: URL for <img src> */ });
 window.__ryn.on('webviewPane.closed',           e => { /* { id } */ });
+window.__ryn.on('webviewPane.processTerminated', e => {
+  // { id, reason } — the pane's web process died (crash/OOM). Recover with reloadFromCrash.
+});
 window.__ryn.on('webviewPane.permissionRequested', async e => {
   // { id, requestId, kinds, url } — kinds ⊂ ['microphone','camera','screenShare','mouseLock',
   //                                          'deviceInfo','geolocation','clipboard','notifications','unknown']
@@ -110,6 +115,20 @@ responds (e.g. a syntax error in the expression) rejects after 10 seconds.
 `setZoom` is native page zoom on macOS (`WKWebView.pageZoom` — crisp, survives
 navigation). On Windows and Linux it applies CSS zoom, re-applied automatically after
 each navigation; layout-affecting but universally supported.
+
+## Crash recovery & suspension
+
+A dying web process (crash, OOM-kill) raises `webviewPane.processTerminated { id, reason }` —
+the pane object survives, showing a blank view. `reloadFromCrash` renavigates to the last known
+URL, which respawns the process. Reasons: `webContentProcessTerminated` (macOS),
+`renderProcessExited`/`browserProcessExited`/… (Windows), `crashed`/`exceededMemoryLimit`/
+`terminatedByApi` (Linux).
+
+`setSuspended` **hides the pane and throttles it** — on WebView2 it is a real process freeze
+(`TrySuspend`; the engine may decline while DevTools is open or a download runs), elsewhere the
+hidden view gets the engine's background throttling. Treat it as "this pane is in the background";
+resume makes the pane visible again. Pane visibility/occlusion tracking stays app-side: your
+frontend owns every pane rect, so it already knows what is covered.
 
 ## Screenshots
 

--- a/src/Ryn.Plugins.WebViewPane/PaneEngineInterop.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneEngineInterop.cs
@@ -160,6 +160,7 @@ internal static unsafe partial class PaneEngineInterop
             "cairo" => ["libcairo.so.2", "libcairo.so"],
             "glib" => ["libglib-2.0.so.0", "libglib-2.0.so"],
             "gobject" => ["libgobject-2.0.so.0", "libgobject-2.0.so"],
+            "gtk" => ["libgtk-4.so.1", "libgtk-4.so", "libgtk-3.so.0", "libgtk-3.so"],
             _ => [],
         };
         foreach (var candidate in candidates)

--- a/src/Ryn.Plugins.WebViewPane/PaneLifecycleInterop.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneLifecycleInterop.cs
@@ -1,0 +1,292 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Ryn.Core.Internal;
+using Ryn.Interop;
+using Ryn.Plugins.WebViewPane.Native;
+
+namespace Ryn.Plugins.WebViewPane;
+
+/// <summary>
+/// Web-process crash detection and best-effort suspension, built per engine:
+/// macOS hooks <c>webViewWebContentProcessDidTerminate:</c> onto saucer's navigation delegate class
+/// (saucer does not implement that selector, so <c>class_addMethod</c> is a clean add — verified against
+/// saucer 8's <c>NavigationDelegate</c>); Windows subscribes <c>ProcessFailed</c> and suspends with
+/// <c>Controller.IsVisible=false</c> + <c>TrySuspend</c> (a real freeze); Linux connects
+/// <c>web-process-terminated</c> and hides the GTK widget (WebKitGTK throttles unmapped views).
+/// Suspending hides the pane on every platform — treat it as "pane is in the background".
+/// </summary>
+internal static unsafe partial class PaneLifecycleInterop
+{
+    /// <summary>Native webview pointer → crash callback. Keyed on the engine handle (idx 0).</summary>
+    private static readonly ConcurrentDictionary<nint, Action<string>> CrashHandlers = new();
+    private static int s_macHookInstalled;
+
+    /// <summary>Registers crash reporting for a pane. Call on the UI thread after creation.</summary>
+    public static void RegisterCrashHandler(saucer_webview* webview, Action<string> onTerminated)
+    {
+        var native = PaneEngineInterop.GetNativeHandle(webview);
+        if (native == 0) return;
+        CrashHandlers[native] = onTerminated;
+
+        if (OperatingSystem.IsMacOS()) InstallMacHook(native);
+        else if (OperatingSystem.IsWindows()) InstallWindowsHook(native);
+        else if (OperatingSystem.IsLinux()) InstallLinuxHook(native);
+    }
+
+    /// <summary>Drops the pane's crash registration. Call before the webview is freed.</summary>
+    public static void UnregisterCrashHandler(saucer_webview* webview)
+    {
+        var native = PaneEngineInterop.GetNativeHandle(webview);
+        if (native != 0) CrashHandlers.TryRemove(native, out _);
+    }
+
+    /// <summary>
+    /// Hides the pane and throttles it: a real process freeze on WebView2 (after the visibility flip),
+    /// a hidden NSView/GtkWidget elsewhere, which the engines background-throttle. Resume reverses it.
+    /// </summary>
+    public static void SetSuspended(saucer_webview* webview, bool suspended)
+    {
+        var native = PaneEngineInterop.GetNativeHandle(webview);
+        if (native == 0)
+            throw new InvalidOperationException("The pane's native webview handle is unavailable.");
+
+        if (OperatingSystem.IsMacOS())
+        {
+            objc_msgSend_bool(native, PaneEngineInterop.sel_registerName("setHidden:"), suspended ? (byte)1 : (byte)0);
+        }
+        else if (OperatingSystem.IsWindows())
+        {
+            SetSuspendedWindows(webview, native, suspended);
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            gtk_widget_set_visible(native, suspended ? (byte)0 : (byte)1);
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("webviewPane.setSuspended is not supported on this OS.");
+        }
+    }
+
+    // --- macOS ---
+
+    [SupportedOSPlatform("macos")]
+    private static void InstallMacHook(nint wkWebView)
+    {
+        var delegateObj = objc_msgSend_ret(wkWebView, PaneEngineInterop.sel_registerName("navigationDelegate"));
+        if (delegateObj == 0) return;
+
+        if (Interlocked.Exchange(ref s_macHookInstalled, 1) == 0)
+        {
+            var cls = object_getClass(delegateObj);
+            var selector = PaneEngineInterop.sel_registerName("webViewWebContentProcessDidTerminate:");
+            // saucer's NavigationDelegate does not implement this optional selector; if a future saucer
+            // does, adding fails and we simply keep saucer's behavior rather than fight over the IMP.
+            _ = class_addMethod(cls, selector,
+                (nint)(delegate* unmanaged[Cdecl]<nint, nint, nint, void>)&OnMacProcessTerminated, "v@:@");
+        }
+
+        // WebKit caches the delegate's respondsToSelector flags at assignment time, so the method we
+        // just added is invisible until the delegate is re-assigned. Re-set it for every new pane.
+        objc_msgSend_set(wkWebView, PaneEngineInterop.sel_registerName("setNavigationDelegate:"), delegateObj);
+    }
+
+    [SupportedOSPlatform("macos")]
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnMacProcessTerminated(nint self, nint selector, nint wkWebView)
+    {
+        NativeGuard.Invoke("PaneLifecycleInterop.OnMacProcessTerminated", () =>
+        {
+            if (CrashHandlers.TryGetValue(wkWebView, out var handler))
+                handler("webContentProcessTerminated");
+        });
+    }
+
+    [LibraryImport("libobjc.dylib")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial nint object_getClass(nint obj);
+
+    [LibraryImport("libobjc.dylib")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.U1)]
+    private static partial bool class_addMethod(nint cls, nint selector, nint imp,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string types);
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial nint objc_msgSend_ret(nint receiver, nint selector);
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial void objc_msgSend_bool(nint receiver, nint selector, byte value);
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial void objc_msgSend_set(nint receiver, nint selector, nint value);
+
+    // --- Windows ---
+
+    private static readonly Guid IidProcessFailedEventHandler = new("79e0aea4-990b-42d9-aa1d-0fcc2e5bc7f1");
+    private static readonly Guid IidCoreWebView2_3 = new("A0D6DF20-3B92-416D-AA0C-437A9C727857");
+    private static readonly Guid IidTrySuspendCompletedHandler = new("00f206a7-9d17-4605-91f6-4e8e4de192e3");
+
+    private const int SlotAddProcessFailed = 25;      // ICoreWebView2::add_ProcessFailed
+    private const int SlotProcessFailedKind = 3;      // ICoreWebView2ProcessFailedEventArgs::get_ProcessFailedKind
+    private const int SlotControllerPutIsVisible = 4; // ICoreWebView2Controller::put_IsVisible
+    private const int SlotTrySuspend = 68;            // ICoreWebView2_3::TrySuspend (3 + 58 + 7)
+    private const int SlotResume = 69;                // ICoreWebView2_3::Resume
+
+    private sealed class WindowsCrashSubscription
+    {
+        public required nint CoreWebView2 { get; init; }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void InstallWindowsHook(nint coreWebView2)
+    {
+        var handler = ComCallback.Create(IidProcessFailedEventHandler,
+            (nint)(delegate* unmanaged[Stdcall]<nint, nint, nint, int>)&OnWindowsProcessFailed,
+            new WindowsCrashSubscription { CoreWebView2 = coreWebView2 });
+
+        var addProcessFailed = (delegate* unmanaged[Stdcall]<nint, nint, long*, int>)
+            (*(nint**)coreWebView2)[SlotAddProcessFailed];
+        long token = 0;
+        _ = addProcessFailed(coreWebView2, handler, &token);
+        ComCallback.Release(handler); // the event source holds its reference until the webview dies
+    }
+
+    [SupportedOSPlatform("windows")]
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static int OnWindowsProcessFailed(nint comThis, nint sender, nint args)
+    {
+        NativeGuard.Invoke("PaneLifecycleInterop.OnWindowsProcessFailed", () =>
+        {
+            var subscription = ComCallback.GetCallback<WindowsCrashSubscription>(comThis);
+            var kind = 9; // UnknownProcessExited
+            if (args != 0)
+            {
+                var getKind = (delegate* unmanaged[Stdcall]<nint, int*, int>)(*(nint**)args)[SlotProcessFailedKind];
+                int value = 0;
+                if (getKind(args, &value) >= 0) kind = value;
+            }
+            if (CrashHandlers.TryGetValue(subscription.CoreWebView2, out var handler))
+                handler(DescribeWindowsProcessFailedKind(kind));
+        });
+        return 0;
+    }
+
+    internal static string DescribeWindowsProcessFailedKind(int kind) => kind switch
+    {
+        0 => "browserProcessExited",
+        1 => "renderProcessExited",
+        2 => "renderProcessUnresponsive",
+        3 => "frameRenderProcessExited",
+        4 => "utilityProcessExited",
+        5 => "sandboxHelperProcessExited",
+        6 => "gpuProcessExited",
+        7 => "ppapiPluginProcessExited",
+        8 => "ppapiBrokerProcessExited",
+        _ => "unknownProcessExited",
+    };
+
+    // CA1508: `core3` is written through a pointer by the native QueryInterface; the analyzer cannot see it.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1508:Avoid dead conditional code",
+        Justification = "Out-params are written by native COM calls the analyzer cannot see.")]
+    [SupportedOSPlatform("windows")]
+    private static void SetSuspendedWindows(saucer_webview* webview, nint coreWebView2, bool suspended)
+    {
+        // Visibility lives on the controller (stable native idx 1); suspension on ICoreWebView2_3.
+        var controller = GetNativeHandleAt(webview, 1);
+        if (controller != 0)
+        {
+            var putIsVisible = (delegate* unmanaged[Stdcall]<nint, int, int>)
+                (*(nint**)controller)[SlotControllerPutIsVisible];
+            _ = putIsVisible(controller, suspended ? 0 : 1);
+        }
+
+        var iid = IidCoreWebView2_3;
+        var queryInterface = (delegate* unmanaged[Stdcall]<nint, Guid*, nint*, int>)(*(nint**)coreWebView2)[0];
+        nint core3 = 0;
+        if (queryInterface(coreWebView2, &iid, &core3) < 0 || core3 == 0)
+            return; // visibility flip alone still throttles rendering
+
+        try
+        {
+            if (suspended)
+            {
+                // Fire-and-forget: TrySuspend legitimately declines (open DevTools, pending downloads).
+                var completed = ComCallback.Create(IidTrySuspendCompletedHandler,
+                    (nint)(delegate* unmanaged[Stdcall]<nint, int, int, int>)&OnTrySuspendCompleted, string.Empty);
+                var trySuspend = (delegate* unmanaged[Stdcall]<nint, nint, int>)(*(nint**)core3)[SlotTrySuspend];
+                _ = trySuspend(core3, completed);
+                ComCallback.Release(completed);
+            }
+            else
+            {
+                var resume = (delegate* unmanaged[Stdcall]<nint, int>)(*(nint**)core3)[SlotResume];
+                _ = resume(core3);
+            }
+        }
+        finally
+        {
+            PaneEngineInterop.ComRelease(core3);
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static int OnTrySuspendCompleted(nint comThis, int errorCode, int isSuccessful) => 0;
+
+    private static nint GetNativeHandleAt(saucer_webview* webview, nuint index)
+    {
+        nuint size = 0;
+        Saucer.saucer_webview_native(webview, index, null, &size);
+        if (size < (nuint)sizeof(nint) || size > 64) return 0;
+        Span<byte> buf = stackalloc byte[(int)size];
+        fixed (byte* ptr = buf)
+        {
+            Saucer.saucer_webview_native(webview, index, ptr, &size);
+            return MemoryMarshal.Read<nint>(buf);
+        }
+    }
+
+    // --- Linux ---
+
+    [SupportedOSPlatform("linux")]
+    private static void InstallLinuxHook(nint webKitWebView)
+    {
+        _ = g_signal_connect_data(webKitWebView, "web-process-terminated",
+            (nint)(delegate* unmanaged[Cdecl]<nint, int, nint, void>)&OnLinuxProcessTerminated,
+            0, 0, 0);
+    }
+
+    [SupportedOSPlatform("linux")]
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnLinuxProcessTerminated(nint webKitWebView, int reason, nint userData)
+    {
+        NativeGuard.Invoke("PaneLifecycleInterop.OnLinuxProcessTerminated", () =>
+        {
+            if (CrashHandlers.TryGetValue(webKitWebView, out var handler))
+                handler(DescribeLinuxTerminationReason(reason));
+        });
+    }
+
+    internal static string DescribeLinuxTerminationReason(int reason) => reason switch
+    {
+        0 => "crashed",
+        1 => "exceededMemoryLimit",
+        2 => "terminatedByApi",
+        _ => "unknown",
+    };
+
+    [LibraryImport("gobject", StringMarshalling = StringMarshalling.Utf8)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial nuint g_signal_connect_data(nint instance, string detailedSignal, nint callback,
+        nint data, nint destroyData, int connectFlags);
+
+    [LibraryImport("gtk")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial void gtk_widget_set_visible(nint widget, byte visible);
+}

--- a/src/Ryn.Plugins.WebViewPane/PaneModels.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneModels.cs
@@ -57,6 +57,13 @@ internal sealed record PanePermissionEvent(int Id, long RequestId, string[] Kind
 /// <summary>ActiveIndex is 0-based; -1 when there are no matches (or the session was stopped).</summary>
 public sealed record PaneFindResult(int Matches, int ActiveIndex);
 
+/// <summary>
+/// Reason strings — macOS: webContentProcessTerminated; Windows: browserProcessExited,
+/// renderProcessExited, renderProcessUnresponsive, and friends; Linux: crashed,
+/// exceededMemoryLimit, terminatedByApi.
+/// </summary>
+internal sealed record PaneProcessTerminatedEvent(int Id, string Reason);
+
 [JsonSerializable(typeof(string))]
 [JsonSerializable(typeof(PaneOpenRequest))]
 [JsonSerializable(typeof(PaneNavigatedEvent))]
@@ -67,5 +74,6 @@ public sealed record PaneFindResult(int Matches, int ActiveIndex);
 [JsonSerializable(typeof(PaneClosedEvent))]
 [JsonSerializable(typeof(PanePermissionEvent))]
 [JsonSerializable(typeof(PaneFindResult))]
+[JsonSerializable(typeof(PaneProcessTerminatedEvent))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class WebViewPaneJsonContext : JsonSerializerContext { }

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
@@ -45,6 +45,12 @@ internal sealed class WebViewPaneCommands
     [RynCommand("webviewPane.setDevTools")]
     public void SetDevTools(int id, bool enabled) => _service.SetDevTools(id, enabled);
 
+    [RynCommand("webviewPane.setSuspended")]
+    public Task SetSuspendedAsync(int id, bool suspended) => _service.SetSuspendedAsync(id, suspended);
+
+    [RynCommand("webviewPane.reloadFromCrash")]
+    public void ReloadFromCrash(int id) => _service.ReloadFromCrash(id);
+
     [RynCommand("webviewPane.screenshot")]
     public Task<string> ScreenshotAsync(int id) => _service.ScreenshotAsync(id);
 

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
@@ -158,6 +158,13 @@ public sealed partial class WebViewPaneService : IDisposable
         Saucer.saucer_webview_on(webview, saucer_webview_event.SAUCER_WEBVIEW_EVENT_PERMISSION,
             (void*)(delegate* unmanaged[Cdecl]<saucer_webview*, saucer_permission_request*, void*, saucer_status>)&OnPermission, 1, userdata);
 
+        PaneLifecycleInterop.RegisterCrashHandler(webview, reason =>
+        {
+            state.Service.Emit("webviewPane.processTerminated", JsonSerializer.Serialize(
+                new PaneProcessTerminatedEvent(state.Id, reason),
+                WebViewPaneJsonContext.Default.PaneProcessTerminatedEvent));
+        });
+
         Saucer.saucer_webview_set_bounds(webview, request.X, request.Y, request.Width, request.Height);
 
         if (request.DevTools)
@@ -201,6 +208,7 @@ public sealed partial class WebViewPaneService : IDisposable
         var webview = (saucer_webview*)state.Webview;
         if (webview != null)
         {
+            PaneLifecycleInterop.UnregisterCrashHandler(webview);
             // Do NOT saucer_webview_off_all before free: on macOS clearing the navigated/favicon
             // listeners tears down saucer's KVO observers, and free then removes them again —
             // NSRangeException ("not registered as an observer") and the app dies. free owns the
@@ -379,6 +387,52 @@ public sealed partial class WebViewPaneService : IDisposable
         var payload = await EvalAsync(id, expression).ConfigureAwait(false);
         return JsonSerializer.Deserialize(payload, WebViewPaneJsonContext.Default.PaneFindResult)
                ?? new PaneFindResult(0, -1);
+    }
+
+    /// <summary>
+    /// Suspends (hide + throttle; a real process freeze on WebView2) or resumes a pane. A suspended
+    /// pane is invisible on every platform — treat suspension as "this pane is in the background".
+    /// </summary>
+    public async Task SetSuspendedAsync(int id, bool suspended)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        PaneState? state;
+        lock (_lock)
+        {
+            _panes.TryGetValue(id, out state);
+        }
+        if (state is null) throw new ArgumentException($"Unknown pane id {id}.", nameof(id));
+
+        Exception? failure = null;
+        await _mainThread.InvokeAsync(() =>
+        {
+            try
+            {
+                if (state.Webview != 0)
+                    SetSuspendedOnUi(state.Webview, suspended);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                failure = ex;
+            }
+        }).ConfigureAwait(false);
+        if (failure is not null) throw failure;
+    }
+
+    private static unsafe void SetSuspendedOnUi(nint webview, bool suspended) =>
+        PaneLifecycleInterop.SetSuspended((saucer_webview*)webview, suspended);
+
+    /// <summary>
+    /// Recovers a pane whose web process died: renavigates to the last known URL (the engines respawn
+    /// the web process on navigation). Pair with the <c>webviewPane.processTerminated</c> event.
+    /// </summary>
+    public void ReloadFromCrash(int id)
+    {
+        WithPane(id, (wv, state) =>
+        {
+            if (!string.IsNullOrEmpty(state.Url)) NavigateOnUi(wv, state.Url);
+            else ReloadOnUi(wv);
+        });
     }
 
     /// <summary>

--- a/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
+++ b/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
@@ -150,6 +150,29 @@ public sealed class WebViewPanePermissionTests
         WebViewPaneService.DescribePermissionKinds(type).Should().Equal(expected);
     }
 
+    [Theory]
+    [InlineData(0, "browserProcessExited")]
+    [InlineData(1, "renderProcessExited")]
+    [InlineData(2, "renderProcessUnresponsive")]
+    [InlineData(6, "gpuProcessExited")]
+    [InlineData(42, "unknownProcessExited")]
+    public void WindowsProcessFailedKinds_MapToReasonStrings(int kind, string expected) =>
+        PaneLifecycleInterop.DescribeWindowsProcessFailedKind(kind).Should().Be(expected);
+
+    [Theory]
+    [InlineData(0, "crashed")]
+    [InlineData(1, "exceededMemoryLimit")]
+    [InlineData(2, "terminatedByApi")]
+    [InlineData(9, "unknown")]
+    public void LinuxTerminationReasons_MapToReasonStrings(int reason, string expected) =>
+        PaneLifecycleInterop.DescribeLinuxTerminationReason(reason).Should().Be(expected);
+
+    [Fact]
+    public void ProcessTerminatedEvent_SerializesCamelCase() =>
+        JsonSerializer.Serialize(new PaneProcessTerminatedEvent(4, "crashed"),
+                WebViewPaneJsonContext.Default.PaneProcessTerminatedEvent)
+            .Should().Be("""{"id":4,"reason":"crashed"}""");
+
     [Fact]
     public void PermissionEvent_SerializesCamelCase()
     {
@@ -197,6 +220,8 @@ public sealed class WebViewPaneDependencyInjectionTests
         await service.Awaiting(s => s.SetUserAgentAsync(1, "")).Should().ThrowAsync<ArgumentException>();
         (await service.ResolvePermissionAsync(12345, grant: true)).Should().BeFalse();
         await service.Awaiting(s => s.ScreenshotAsync(99)).Should().ThrowAsync<ArgumentException>();
+        await service.Awaiting(s => s.SetSuspendedAsync(99, true)).Should().ThrowAsync<ArgumentException>();
+        service.Invoking(s => s.ReloadFromCrash(99)).Should().NotThrow();
     }
 
     private sealed class NoopDispatcher : IMainThreadDispatcher


### PR DESCRIPTION
- `webviewPane.processTerminated { id, reason }` on web-process death, `reloadFromCrash` to recover, `setSuspended` to background-throttle
- Per-engine: `webViewWebContentProcessDidTerminate:` hook on saucer's nav delegate (macOS), `ProcessFailed` (WebView2), `web-process-terminated` (WebKitGTK)
- Verified live on macOS — crash event fires with correct pane id/reason; suspend/resume round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCHwBNFMx7my96k3rSwidW