### PR TITLE
feat: add Windows CDP passthrough to webview panes

### DIFF
--- a/docs/webview-panes.md
+++ b/docs/webview-panes.md
@@ -168,6 +168,22 @@ still work — only the visual highlight is missing. Sessions are page-scoped: a
 them, and matches spanning element boundaries (`ab<b>cd</b>`) are not found. Searching an empty
 string returns `{ matches: 0, activeIndex: -1 }` without error.
 
+## DevTools Protocol (Windows only)
+
+WebView2 exposes a real Chrome DevTools Protocol endpoint, so on **Windows** a pane can drive CDP
+directly:
+
+```js
+const metrics = await window.__ryn.invoke('webviewPane.cdpCall',
+  { id, method: 'Page.getLayoutMetrics', paramsJson: '{}' });        // → result JSON
+await window.__ryn.invoke('webviewPane.cdpSubscribe', { id, event: 'Network.responseReceived' });
+window.__ryn.on('webviewPane.cdpEvent', e => { /* { id, event, paramsJson } */ });
+```
+
+macOS (WKWebView) and Linux (WebKitGTK) have **no public DevTools Protocol**, so `cdpCall` and
+`cdpSubscribe` reject with a typed "unsupported" error there (they never hang) — use `eval` for the
+scriptable subset on those platforms.
+
 ## Permission prompts
 
 When a page in a pane asks for a sensitive capability (getUserMedia, geolocation, …) the
@@ -196,7 +212,8 @@ should share a session. Omitting it uses the engine's default (shared) session.
 `OpenAsync(PaneOpenRequest)`, `CloseAsync`, `SetBounds`, `Navigate`, `Back`, `Forward`,
 `Reload`, `SetZoom`, `SetDevTools`, `SetUserAgentAsync`, `ScreenshotAsync`, `FindAsync`,
 `FindNextAsync`, `FindStopAsync`, `ResolvePermissionAsync`, `ResolveDownloadAsync`,
-`SetSuspendedAsync`, `ReloadFromCrash`, `Execute`, `EvalAsync`, `GetUrl`, `List`, `CloseAll`.
+`SetSuspendedAsync`, `ReloadFromCrash`, `CdpCallAsync`, `CdpSubscribeAsync`, `Execute`,
+`EvalAsync`, `GetUrl`, `List`, `CloseAll`.
 
 ## Platform notes
 

--- a/src/Ryn.Plugins.WebViewPane/PaneCdpInterop.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneCdpInterop.cs
@@ -1,0 +1,160 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using Ryn.Core.Internal;
+using Ryn.Interop;
+using Ryn.Plugins.WebViewPane.Native;
+
+namespace Ryn.Plugins.WebViewPane;
+
+/// <summary>
+/// Chrome DevTools Protocol passthrough, Windows-only. WebView2 exposes a real CDP endpoint
+/// (<c>CallDevToolsProtocolMethod</c> / <c>GetDevToolsProtocolEventReceiver</c>); WKWebView and
+/// WebKitGTK have no public equivalent, so those platforms throw a typed "unsupported" error rather
+/// than hang. The native handle saucer hands out on Windows is already <c>ICoreWebView2_2*</c>, which
+/// derives from <c>ICoreWebView2</c> where these methods live.
+/// </summary>
+internal static unsafe partial class PaneCdpInterop
+{
+    private const int SlotCallDevToolsProtocolMethod = 36; // IUnknown(3) + ICoreWebView2 local 33
+    private const int SlotGetDevToolsProtocolEventReceiver = 42; // local 39
+    private const int SlotReceiverAddEvent = 3;              // ICoreWebView2DevToolsProtocolEventReceiver local 0
+    private const int SlotEventArgsGetParameterJson = 3;     // ICoreWebView2DevToolsProtocolEventReceivedEventArgs local 0
+
+    private static readonly Guid IidCallCompletedHandler = new("5c4889f0-5ef6-4c5a-952c-d8f1b92d0574");
+    private static readonly Guid IidEventReceivedHandler = new("e2fda4be-5456-406c-a261-3d452138362c");
+
+    /// <summary>Boxes a value type for ComCallback's reference-typed callback slot.</summary>
+    private sealed class Ref<T>(T value) where T : class { public T Value { get; } = value; }
+
+    private static long s_nextCallId;
+    private static readonly ConcurrentDictionary<long, TaskCompletionSource<string>> PendingCalls = new();
+
+    /// <summary>
+    /// Calls a CDP method and completes with the JSON result. Throws
+    /// <see cref="PlatformNotSupportedException"/> off Windows.
+    /// </summary>
+    public static Task<string> CallAsync(saucer_webview* webview, string method, string paramsJson)
+    {
+        if (!OperatingSystem.IsWindows())
+            return Task.FromException<string>(new PlatformNotSupportedException(
+                "webviewPane.cdpCall is only supported on Windows (WebView2). macOS and Linux have no public DevTools Protocol."));
+
+        var native = PaneEngineInterop.GetNativeHandle(webview);
+        if (native == 0)
+            return Task.FromException<string>(new InvalidOperationException("The pane's native webview handle is unavailable."));
+
+        return CallWindows(native, method, string.IsNullOrEmpty(paramsJson) ? "{}" : paramsJson);
+    }
+
+    /// <summary>
+    /// Subscribes to a CDP event; each occurrence invokes <paramref name="onEvent"/> with the event's
+    /// parameter JSON. Throws <see cref="PlatformNotSupportedException"/> off Windows.
+    /// </summary>
+    public static void Subscribe(saucer_webview* webview, string eventName, Action<string> onEvent)
+    {
+        if (!OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException(
+                "webviewPane.cdpSubscribe is only supported on Windows (WebView2).");
+
+        var native = PaneEngineInterop.GetNativeHandle(webview);
+        if (native == 0)
+            throw new InvalidOperationException("The pane's native webview handle is unavailable.");
+
+        SubscribeWindows(native, eventName, onEvent);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static Task<string> CallWindows(nint coreWebView2, string method, string paramsJson)
+    {
+        var callId = Interlocked.Increment(ref s_nextCallId);
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        PendingCalls[callId] = tcs;
+
+        var handler = ComCallback.Create(IidCallCompletedHandler,
+            (nint)(delegate* unmanaged[Stdcall]<nint, int, char*, int>)&OnCallCompleted, new Ref<TaskCompletionSource<string>>(tcs));
+
+        var call = (delegate* unmanaged[Stdcall]<nint, char*, char*, nint, int>)(*(nint**)coreWebView2)[SlotCallDevToolsProtocolMethod];
+        int hr;
+        fixed (char* m = method)
+        fixed (char* p = paramsJson)
+        {
+            hr = call(coreWebView2, m, p, handler);
+        }
+        ComCallback.Release(handler);
+
+        if (hr < 0)
+        {
+            PendingCalls.TryRemove(callId, out _);
+            tcs.TrySetException(new InvalidOperationException($"CallDevToolsProtocolMethod failed (HRESULT 0x{hr:X8})."));
+        }
+        return tcs.Task;
+    }
+
+    [SupportedOSPlatform("windows")]
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static int OnCallCompleted(nint comThis, int errorCode, char* returnJson)
+    {
+        var tcs = ComCallback.GetCallback<Ref<TaskCompletionSource<string>>>(comThis).Value;
+        NativeGuard.Invoke("PaneCdpInterop.OnCallCompleted", () =>
+        {
+            if (errorCode < 0)
+                tcs.TrySetException(new InvalidOperationException($"CDP method failed (HRESULT 0x{errorCode:X8})."));
+            else
+                tcs.TrySetResult(returnJson == null ? "{}" : new string(returnJson));
+        });
+        return 0;
+    }
+
+    // CA1508: receiver is written through the out-pointer by the native getter.
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1508:Avoid dead conditional code",
+        Justification = "Out-params are written by native COM calls the analyzer cannot see.")]
+    [SupportedOSPlatform("windows")]
+    private static void SubscribeWindows(nint coreWebView2, string eventName, Action<string> onEvent)
+    {
+        var getReceiver = (delegate* unmanaged[Stdcall]<nint, char*, nint*, int>)(*(nint**)coreWebView2)[SlotGetDevToolsProtocolEventReceiver];
+        nint receiver = 0;
+        int hr;
+        fixed (char* e = eventName)
+        {
+            hr = getReceiver(coreWebView2, e, &receiver);
+        }
+        if (hr < 0 || receiver == 0)
+            throw new InvalidOperationException($"GetDevToolsProtocolEventReceiver failed (HRESULT 0x{hr:X8}).");
+
+        try
+        {
+            var handler = ComCallback.Create(IidEventReceivedHandler,
+                (nint)(delegate* unmanaged[Stdcall]<nint, nint, nint, int>)&OnEventReceived, new Ref<Action<string>>(onEvent));
+            var add = (delegate* unmanaged[Stdcall]<nint, nint, long*, int>)(*(nint**)receiver)[SlotReceiverAddEvent];
+            long token = 0;
+            _ = add(receiver, handler, &token);
+            ComCallback.Release(handler); // the receiver holds its reference
+        }
+        finally
+        {
+            PaneEngineInterop.ComRelease(receiver);
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static int OnEventReceived(nint comThis, nint sender, nint args)
+    {
+        var onEvent = ComCallback.GetCallback<Ref<Action<string>>>(comThis).Value;
+        NativeGuard.Invoke("PaneCdpInterop.OnEventReceived", () =>
+        {
+            if (args == 0) return;
+            var getJson = (delegate* unmanaged[Stdcall]<nint, char**, int>)(*(nint**)args)[SlotEventArgsGetParameterJson];
+            char* json = null;
+            if (getJson(args, &json) >= 0 && json != null)
+            {
+                var payload = new string(json);
+                Marshal.FreeCoTaskMem((nint)json);
+                onEvent(payload);
+            }
+        });
+        return 0;
+    }
+}

--- a/src/Ryn.Plugins.WebViewPane/PaneModels.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneModels.cs
@@ -73,6 +73,9 @@ internal sealed record PaneDownloadCompletedEvent(int Id, long DownloadId, strin
 
 internal sealed record PaneDownloadFailedEvent(int Id, long DownloadId, string Error);
 
+/// <summary>ParamsJson is the CDP event's parameter object, verbatim. Windows only.</summary>
+internal sealed record PaneCdpEvent(int Id, string Event, string ParamsJson);
+
 [JsonSerializable(typeof(string))]
 [JsonSerializable(typeof(PaneOpenRequest))]
 [JsonSerializable(typeof(PaneNavigatedEvent))]
@@ -88,5 +91,6 @@ internal sealed record PaneDownloadFailedEvent(int Id, long DownloadId, string E
 [JsonSerializable(typeof(PaneDownloadProgressEvent))]
 [JsonSerializable(typeof(PaneDownloadCompletedEvent))]
 [JsonSerializable(typeof(PaneDownloadFailedEvent))]
+[JsonSerializable(typeof(PaneCdpEvent))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class WebViewPaneJsonContext : JsonSerializerContext { }

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
@@ -45,6 +45,13 @@ internal sealed class WebViewPaneCommands
     [RynCommand("webviewPane.setDevTools")]
     public void SetDevTools(int id, bool enabled) => _service.SetDevTools(id, enabled);
 
+    [RynCommand("webviewPane.cdpCall")]
+    public Task<string> CdpCallAsync(int id, string method, string? paramsJson) =>
+        _service.CdpCallAsync(id, method, paramsJson ?? "{}");
+
+    [RynCommand("webviewPane.cdpSubscribe")]
+    public Task CdpSubscribeAsync(int id, string eventName) => _service.CdpSubscribeAsync(id, eventName);
+
     [RynCommand("webviewPane.resolveDownload")]
     public Task ResolveDownloadAsync(long downloadId, string action, string? path) =>
         _service.ResolveDownloadAsync(downloadId,

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
@@ -515,6 +515,78 @@ public sealed partial class WebViewPaneService : IDisposable
     private static unsafe void StartScreenshotOnUi(nint webview, Action<byte[]?, string?> completion) =>
         PaneScreenshotInterop.Start((saucer_webview*)webview, completion);
 
+    /// <summary>
+    /// Calls a Chrome DevTools Protocol method on the pane and returns the JSON result. Windows only
+    /// (WebView2); throws on macOS/Linux, which have no public DevTools Protocol.
+    /// </summary>
+    public async Task<string> CdpCallAsync(int id, string method, string paramsJson)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(method);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        PaneState? state;
+        lock (_lock)
+        {
+            _panes.TryGetValue(id, out state);
+        }
+        if (state is null) throw new ArgumentException($"Unknown pane id {id}.", nameof(id));
+
+        Task<string>? call = null;
+        Exception? failure = null;
+        await _mainThread.InvokeAsync(() =>
+        {
+            try
+            {
+                if (state.Webview != 0) call = CdpCallOnUi(state.Webview, method, paramsJson ?? "{}");
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                failure = ex;
+            }
+        }).ConfigureAwait(false);
+        if (failure is not null) throw failure;
+        if (call is null) throw new InvalidOperationException("The pane was closed.");
+        return await call.ConfigureAwait(false);
+    }
+
+    private static unsafe Task<string> CdpCallOnUi(nint webview, string method, string paramsJson) =>
+        PaneCdpInterop.CallAsync((saucer_webview*)webview, method, paramsJson);
+
+    /// <summary>
+    /// Subscribes the pane to a CDP event; each occurrence is emitted as <c>webviewPane.cdpEvent</c>
+    /// carrying the pane id, event name, and parameter JSON. Windows only.
+    /// </summary>
+    public async Task CdpSubscribeAsync(int id, string eventName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(eventName);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        PaneState? state;
+        lock (_lock)
+        {
+            _panes.TryGetValue(id, out state);
+        }
+        if (state is null) throw new ArgumentException($"Unknown pane id {id}.", nameof(id));
+
+        Exception? failure = null;
+        await _mainThread.InvokeAsync(() =>
+        {
+            try
+            {
+                if (state.Webview != 0)
+                    CdpSubscribeOnUi(state.Webview, eventName, payload => state.Service.Emit("webviewPane.cdpEvent",
+                        JsonSerializer.Serialize(new PaneCdpEvent(state.Id, eventName, payload),
+                            WebViewPaneJsonContext.Default.PaneCdpEvent)));
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                failure = ex;
+            }
+        }).ConfigureAwait(false);
+        if (failure is not null) throw failure;
+    }
+
+    private static unsafe void CdpSubscribeOnUi(nint webview, string eventName, Action<string> onEvent) =>
+        PaneCdpInterop.Subscribe((saucer_webview*)webview, eventName, onEvent);
+
     /// <summary>The pane's current URL as last reported by navigation events.</summary>
     public string GetUrl(int id)
     {

--- a/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
+++ b/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
@@ -233,6 +233,7 @@ public sealed class WebViewPaneDependencyInjectionTests
         await service.Awaiting(s => s.SetUserAgentAsync(99, "UA/1.0")).Should().ThrowAsync<ArgumentException>();
         await service.Awaiting(s => s.SetUserAgentAsync(1, "")).Should().ThrowAsync<ArgumentException>();
         (await service.ResolvePermissionAsync(12345, grant: true)).Should().BeFalse();
+        await service.Awaiting(s => s.CdpCallAsync(99, "Page.enable", "{}")).Should().ThrowAsync<ArgumentException>();
         await service.Awaiting(s => s.ScreenshotAsync(99)).Should().ThrowAsync<ArgumentException>();
         await service.Awaiting(s => s.SetSuspendedAsync(99, true)).Should().ThrowAsync<ArgumentException>();
         service.Invoking(s => s.ReloadFromCrash(99)).Should().NotThrow();


### PR DESCRIPTION
- `webviewPane.cdpCall { id, method, paramsJson }` → result JSON; `cdpSubscribe { id, event }` + `cdpEvent` stream — Windows/WebView2 only
- macOS/Linux reject with a typed unsupported error (never hang), verified live on macOS
- Reuses the AOT COM handler infra from the screenshot/download work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCHwBNFMx7my96k3rSwidW