### PR TITLE
fix: menu items with empty children arrays are now clickable

### DIFF
--- a/docs/custom-title-bars.md
+++ b/docs/custom-title-bars.md
@@ -5,6 +5,15 @@ To make a region of that HTML drag the window, resize it, or act as a window but
 attribute to the element. The webview hit-tests these attributes **inside the `mousedown` event** and
 performs the native action immediately — no IPC round-trip, no lag.
 
+## Which `TitleBarStyle` for a custom title bar?
+
+**Drawing your own title bar in HTML? Use `Overlay`.** On macOS `Overlay` gives the webview the full window
+height (`fullSizeContentView`) with a transparent title bar and native traffic lights floating on top, so
+your page reaches the very top edge. `Hidden` instead leaves an **empty native title-bar strip** above the
+webview — your content renders *below* it, and with a transparent/`Backdrop` window that strip reads as a
+see-through band around the traffic lights. `Frameless` removes all chrome (no traffic lights). Use `Hidden`
+only when you want the native strip but no title text; use `Overlay` for edge-to-edge custom chrome.
+
 ## Dragging
 
 ```html

--- a/docs/window-backdrop.md
+++ b/docs/window-backdrop.md
@@ -28,6 +28,11 @@ await window.__ryn.invoke('window.setBackdrop', { material: 'mica' }); // none|b
 const applied = await window.__ryn.invoke('window.getBackdrop');       // "none" if degraded
 ```
 
+> The JS `window.setBackdrop` / `window.getBackdrop` commands (like all `window.*` commands) require the
+> **`window`** capability in `ryn.json` (`{ "capabilities": { "window": true } }`). Without it the call is
+> denied — the rejection surfaces only as a host-stdout warning and a rejected promise, so add the capability
+> if a `window.*` invoke silently fails. The C# `IRynWindow.SetBackdrop`/`GetBackdrop` are not gated.
+
 ## Platform support
 
 | Material | macOS | Windows 11 (22H2+) | Windows 10 | Linux |

--- a/src/Ryn.Plugins.MenuBar/Backends/MacOsMenuBarBackend.cs
+++ b/src/Ryn.Plugins.MenuBar/Backends/MacOsMenuBarBackend.cs
@@ -159,7 +159,9 @@ internal sealed partial class MacOsMenuBarBackend : IMenuBarBackend
                 continue;
             }
 
-            if (item.Items is not null)
+            // A submenu only when it actually has children; an empty (non-null) Items — a JSON `items: []`
+            // leaf — must stay a clickable custom item, not a dead targetless submenu. See MenuBarItem.IsSubmenu.
+            if (item.IsSubmenu)
             {
                 var holderAlloc = objc_msgSend_ret_nint(
                     (void*)objc_getClass("NSMenuItem"), sel_registerName("alloc"));
@@ -168,7 +170,7 @@ internal sealed partial class MacOsMenuBarBackend : IMenuBarBackend
                     sel_registerName("initWithTitle:action:keyEquivalent:"),
                     CreateNSString(item.Label ?? item.Id ?? string.Empty), 0, CreateNSString(""));
 
-                var submenu = BuildMenu(item.Label ?? string.Empty, item.Items);
+                var submenu = BuildMenu(item.Label ?? string.Empty, item.Items!);
                 objc_msgSend_ptr(holder, sel_registerName("setSubmenu:"), (void*)submenu);
                 objc_msgSend_ret_nint((void*)submenu, sel_registerName("release"));
 
@@ -313,9 +315,17 @@ internal sealed partial class MacOsMenuBarBackend : IMenuBarBackend
             lock (instance._lock)
             {
                 if (tag >= 0 && tag < instance._customIds.Count)
+                {
                     itemId = instance._customIds[tag];
+                }
                 else
+                {
+                    // A click on an item whose tag no longer maps (e.g. a rebuild raced the click). Surface it
+                    // rather than dropping silently — this class of no-op cost a downstream integrator an hour.
+                    System.Diagnostics.Trace.TraceWarning(
+                        $"MenuBar: click dropped — item tag {tag} out of range (custom items: {instance._customIds.Count}).");
                     return;
+                }
             }
             instance.MenuItemClicked?.Invoke(itemId);
         });

--- a/src/Ryn.Plugins.MenuBar/Backends/WindowsMenuBarBackend.cs
+++ b/src/Ryn.Plugins.MenuBar/Backends/WindowsMenuBarBackend.cs
@@ -114,9 +114,11 @@ internal sealed partial class WindowsMenuBarBackend : IMenuBarBackend
                 continue;
             }
 
-            if (item.Items is not null)
+            // Submenu only when it has children; an empty (non-null) Items — a JSON `items: []` leaf — must
+            // stay a clickable command, not a dead popup. See MenuBarItem.IsSubmenu.
+            if (item.IsSubmenu)
             {
-                var submenu = BuildPopup(item.Items, ref nextId);
+                var submenu = BuildPopup(item.Items!, ref nextId);
                 AppendMenu(menu, MfPopup, submenu, item.Label ?? item.Id ?? string.Empty);
                 continue;
             }

--- a/src/Ryn.Plugins.MenuBar/MenuBarItem.cs
+++ b/src/Ryn.Plugins.MenuBar/MenuBarItem.cs
@@ -38,4 +38,12 @@ public sealed class MenuBarItem
 
     /// <summary>Child items; set on top-level menus and submenus.</summary>
     public IReadOnlyList<MenuBarItem>? Items { get; init; }
+
+    /// <summary>
+    /// Whether this nested item is a submenu (has children) versus a clickable leaf. An item that arrives
+    /// with an <b>empty</b> <see cref="Items"/> list — the shape a JSON <c>items: []</c> deserializes to,
+    /// which frontends emit for every leaf via <c>children.map()</c> — is a leaf, not a dead submenu. Only
+    /// consulted for nested items; a top-level entry is always a menu.
+    /// </summary>
+    internal bool IsSubmenu => Items is { Count: > 0 };
 }

--- a/src/Ryn.Plugins.MenuBar/MenuBarPlugin.cs
+++ b/src/Ryn.Plugins.MenuBar/MenuBarPlugin.cs
@@ -1,10 +1,11 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Ryn.Core;
 
 namespace Ryn.Plugins.MenuBar;
 
 #pragma warning disable CA1812 // Instantiated by DI
-internal sealed class MenuBarPlugin : IRynPlugin
+internal sealed partial class MenuBarPlugin : IRynPlugin
 #pragma warning restore CA1812
 {
     private readonly IServiceProvider _services;
@@ -16,14 +17,26 @@ internal sealed class MenuBarPlugin : IRynPlugin
     public ValueTask InitializeAsync(CancellationToken cancellationToken)
     {
         var menuBarService = _services.GetRequiredService<MenuBarService>();
+        var logger = _services.GetService<ILoggerFactory>()?.CreateLogger("Ryn.Plugins.MenuBar");
         menuBarService.EmitEvent = (eventName, jsonData) =>
         {
             var webView = _services.GetService<IRynWebView>();
-            webView?.EmitEvent(eventName, jsonData);
+            if (webView is null)
+            {
+                // Without a webview the event can't reach the page — a silent drop here once cost a
+                // downstream integrator an hour diagnosing dead menu clicks. Make it visible.
+                if (logger is not null) LogEventDropped(logger, eventName);
+                return;
+            }
+            webView.EmitEvent(eventName, jsonData);
         };
         // Queued through the main-thread dispatcher, which buffers pre-loop work — the standard menu is in
         // place from the first frame the event loop renders.
         menuBarService.ApplyStartupMenu();
         return ValueTask.CompletedTask;
     }
+
+    [LoggerMessage(Level = LogLevel.Warning,
+        Message = "MenuBar event '{eventName}' dropped: no IRynWebView is available to deliver it to the page.")]
+    private static partial void LogEventDropped(ILogger logger, string eventName);
 }

--- a/tests/Ryn.Plugins.Tests/MenuBarTests.cs
+++ b/tests/Ryn.Plugins.Tests/MenuBarTests.cs
@@ -122,6 +122,29 @@ public sealed class MenuBarDefaultsTests
     }
 
     [Fact]
+    public void IsSubmenu_TreatsEmptyItemsAsLeaf_NotSubmenu()
+    {
+        // Regression: a leaf that arrives with `items: []` (the shape frontends emit via children.map())
+        // must be a clickable custom item, not a dead targetless submenu. Broke every menu click in 0.20.
+        new MenuBarItem { Id = "x", Label = "X" }.IsSubmenu.Should().BeFalse();                 // Items null
+        new MenuBarItem { Id = "x", Label = "X", Items = [] }.IsSubmenu.Should().BeFalse();     // Items empty
+        new MenuBarItem { Label = "M", Items = [new MenuBarItem { Id = "c" }] }.IsSubmenu       // Items with a child
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetMenuCommand_DeserializesEmptyItemsArray_AsEmptyNotNull()
+    {
+        // Proves the deserialized shape that triggered the bug: `items: []` → non-null empty list → IsSubmenu false.
+        var items = System.Text.Json.JsonSerializer.Deserialize(
+            """[{"label":"View","items":[{"id":"zen","label":"Zen","items":[]}]}]""",
+            MenuBarJsonContext.Default.MenuBarItemArray)!;
+        var leaf = items[0].Items![0];
+        leaf.Items.Should().NotBeNull().And.BeEmpty();
+        leaf.IsSubmenu.Should().BeFalse();
+    }
+
+    [Fact]
     public void EveryRole_UsedByDefaultMenus_IsKnown()
     {
         var menus = MenuBarDefaults.CreateDefault("TestApp");


### PR DESCRIPTION
Fixes Cove's P0: `menubar.itemClicked` never fired on macOS. A leaf item arriving with `items: []` (what a frontend's `children.map()` emits, and what JSON deserializes to) was classified as a submenu and built with no target/action — so it rendered but clicks and accelerators did nothing, with no error. Reproduced end-to-end (AX click) and fixed in both the macOS and Windows backends via a shared `MenuBarItem.IsSubmenu` (submenu only when it has children).

Also: makes dropped menubar emits visible (DX request), and two doc notes (Hidden vs Overlay title bars; the `window` capability for backdrop commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCHwBNFMx7my96k3rSwidW