### PR TITLE
fix: menu item Enabled defaults to true through the JSON path

### DIFF
--- a/src/Ryn.Plugins.MenuBar/MenuBarItem.cs
+++ b/src/Ryn.Plugins.MenuBar/MenuBarItem.cs
@@ -32,7 +32,21 @@ public sealed class MenuBarItem
     /// </summary>
     public string? Accelerator { get; init; }
 
-    public bool Enabled { get; init; } = true;
+    private readonly bool? _enabled;
+
+    /// <summary>
+    /// Serialization shim for <c>enabled</c>. It is <b>nullable</b> on purpose: the System.Text.Json
+    /// source generator sets an absent <i>non-nullable</i> <c>init</c> property to its default (<c>false</c>)
+    /// instead of running a <c>= true</c> initializer, which silently built every menu item disabled
+    /// (rendered fine, never dispatched). A nullable target's natural absent value is <c>null</c>, so
+    /// <see cref="Enabled"/> can distinguish "omitted" from "explicitly false". Prefer <see cref="Enabled"/>.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("enabled")]
+    public bool? EnabledRaw { get => _enabled; init => _enabled = value; }
+
+    /// <summary>Whether the item is enabled (clickable). Defaults to <c>true</c> when unspecified.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public bool Enabled { get => _enabled ?? true; init => _enabled = value; }
 
     public bool Separator { get; init; }
 

--- a/src/Ryn.Plugins.Tray/Ryn.Plugins.Tray.csproj
+++ b/src/Ryn.Plugins.Tray/Ryn.Plugins.Tray.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Ryn.Plugins.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Ryn.Core\Ryn.Core.csproj" />
     <ProjectReference Include="..\Ryn.Ipc\Ryn.Ipc.csproj" />
     <ProjectReference Include="..\Ryn.Ipc.Generator\Ryn.Ipc.Generator.csproj"

--- a/src/Ryn.Plugins.Tray/TrayCommands.cs
+++ b/src/Ryn.Plugins.Tray/TrayCommands.cs
@@ -4,7 +4,10 @@ using Ryn.Ipc;
 
 namespace Ryn.Plugins.Tray;
 
+// CamelCase to match the IPC convention every other plugin uses — tray.setMenu items arrive as
+// {"id":…,"label":…}. Without it the required Id/Label never bind and deserialization throws.
 [JsonSerializable(typeof(TrayMenuItem[]))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class TrayJsonContext : JsonSerializerContext { }
 
 [RynJsonContext(typeof(TrayJsonContext))]

--- a/src/Ryn.Plugins.Tray/TrayMenuItem.cs
+++ b/src/Ryn.Plugins.Tray/TrayMenuItem.cs
@@ -4,6 +4,20 @@ public sealed class TrayMenuItem
 {
     public required string Id { get; init; }
     public required string Label { get; init; }
-    public bool Enabled { get; init; } = true;
+
+    private readonly bool? _enabled;
+
+    /// <summary>
+    /// Serialization shim for <c>enabled</c>, nullable on purpose — see <c>MenuBarItem.EnabledRaw</c>: the STJ
+    /// source generator sets an absent non-nullable <c>init</c> property to <c>false</c> rather than running a
+    /// <c>= true</c> initializer, which would disable the item. Prefer <see cref="Enabled"/>.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("enabled")]
+    public bool? EnabledRaw { get => _enabled; init => _enabled = value; }
+
+    /// <summary>Whether the item is enabled. Defaults to <c>true</c> when unspecified.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public bool Enabled { get => _enabled ?? true; init => _enabled = value; }
+
     public bool Separator { get; init; }
 }

--- a/tests/Ryn.Plugins.Tests/MenuBarTests.cs
+++ b/tests/Ryn.Plugins.Tests/MenuBarTests.cs
@@ -145,6 +145,30 @@ public sealed class MenuBarDefaultsTests
     }
 
     [Fact]
+    public void Enabled_DefaultsToTrue_WhenAbsentFromJson()
+    {
+        // Regression: `enabled` absent from the setMenu JSON must deserialize to true. A `= true` initializer
+        // is dropped by some STJ source-generator versions (absent members skip initializers), which built
+        // every item disabled on the shipped 0.20.1 binary. The default now lives in the getter, not an
+        // initializer, so it holds regardless of the generator.
+        var absent = System.Text.Json.JsonSerializer.Deserialize(
+            """[{"id":"x","label":"X"}]""", MenuBarJsonContext.Default.MenuBarItemArray)!;
+        absent[0].Enabled.Should().BeTrue();
+
+        var explicitFalse = System.Text.Json.JsonSerializer.Deserialize(
+            """[{"id":"x","label":"X","enabled":false}]""", MenuBarJsonContext.Default.MenuBarItemArray)!;
+        explicitFalse[0].Enabled.Should().BeFalse();
+
+        var explicitTrue = System.Text.Json.JsonSerializer.Deserialize(
+            """[{"id":"x","label":"X","enabled":true}]""", MenuBarJsonContext.Default.MenuBarItemArray)!;
+        explicitTrue[0].Enabled.Should().BeTrue();
+
+        // C# initializer still works (non-breaking).
+        new MenuBarItem { Id = "x", Enabled = false }.Enabled.Should().BeFalse();
+        new MenuBarItem { Id = "x" }.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
     public void EveryRole_UsedByDefaultMenus_IsKnown()
     {
         var menus = MenuBarDefaults.CreateDefault("TestApp");

--- a/tests/Ryn.Plugins.Tests/Ryn.Plugins.Tests.csproj
+++ b/tests/Ryn.Plugins.Tests/Ryn.Plugins.Tests.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\..\src\Ryn.Plugins.Badge\Ryn.Plugins.Badge.csproj" />
     <ProjectReference Include="..\..\src\Ryn.Plugins.GlobalShortcut\Ryn.Plugins.GlobalShortcut.csproj" />
     <ProjectReference Include="..\..\src\Ryn.Plugins.MenuBar\Ryn.Plugins.MenuBar.csproj" />
+    <ProjectReference Include="..\..\src\Ryn.Plugins.Tray\Ryn.Plugins.Tray.csproj" />
     <ProjectReference Include="..\..\src\Ryn.Plugins.Notification\Ryn.Plugins.Notification.csproj" />
     <ProjectReference Include="..\..\src\Ryn.Plugins.Audio\Ryn.Plugins.Audio.csproj" />
     <ProjectReference Include="..\..\src\Ryn.Plugins.Updater\Ryn.Plugins.Updater.csproj" />

--- a/tests/Ryn.Plugins.Tests/TrayMenuItemJsonTests.cs
+++ b/tests/Ryn.Plugins.Tests/TrayMenuItemJsonTests.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using FluentAssertions;
+using Ryn.Plugins.Tray;
+using Xunit;
+
+namespace Ryn.Plugins.Tests;
+
+public sealed class TrayMenuItemJsonTests
+{
+    [Fact]
+    public void Enabled_DefaultsToTrue_WhenAbsentFromJson()
+    {
+        // Same latent bug as MenuBarItem: a `= true` initializer is dropped by some STJ source-generator
+        // versions for members absent from the JSON, disabling every tray item. The default lives in the
+        // getter now, so an omitted `enabled` stays true.
+        var absent = JsonSerializer.Deserialize(
+            """[{"id":"x","label":"X"}]""", TrayJsonContext.Default.TrayMenuItemArray)!;
+        absent[0].Enabled.Should().BeTrue();
+
+        var disabled = JsonSerializer.Deserialize(
+            """[{"id":"x","label":"X","enabled":false}]""", TrayJsonContext.Default.TrayMenuItemArray)!;
+        disabled[0].Enabled.Should().BeFalse();
+
+        new TrayMenuItem { Id = "x", Label = "X", Enabled = false }.Enabled.Should().BeFalse();
+        new TrayMenuItem { Id = "x", Label = "X" }.Enabled.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Fixes the real cause of Cove's dead menu clicks (v0.20.1's `items: []` fix was a separate, unrelated bug). `MenuBarItem.Enabled { get; init; } = true` deserialized to **false** when `enabled` was absent from the setMenu JSON — the STJ source generator sets an absent non-nullable `init` property to its default rather than running the initializer, so every item built disabled: rendered fine, never dispatched, no callback, no error. Reproduced locally through the real IPC path (AX click) and via unit test.

The fix backs `Enabled` with a nullable `EnabledRaw` JSON shim (null when absent → default `true`); `Enabled` stays a settable `bool`, so C# construction is unchanged. Same latent bug fixed on `TrayMenuItem.Enabled`. Also aligned `TrayJsonContext` to camelCase (it was throwing on the standard `{id,label}` payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCHwBNFMx7my96k3rSwidW