### PR TITLE
feat: implement the data-webview-* custom title bar contract

### DIFF
--- a/docs/custom-title-bars.md
+++ b/docs/custom-title-bars.md
@@ -2,8 +2,22 @@
 
 A frameless or overlay window (set `RynWindowOptions.TitleBarStyle`) lets your HTML own the title-bar area.
 To make a region of that HTML drag the window, resize it, or act as a window button, add a `data-webview-*`
-attribute to the element. The webview hit-tests these attributes **inside the `mousedown` event** and
-performs the native action immediately — no IPC round-trip, no lag.
+attribute to the element. Ryn injects a small script (for every non-`Native` title-bar style) that wires
+these up.
+
+> **Capability.** The drag/control attributes call `window.*` commands, so an app with a `ryn.json` must
+> grant the **`window`** capability (`{ "capabilities": { "window": true } }`). Without it the calls are
+> denied (a host-stdout warning + rejected promise) and the title bar appears inert. Dev mode with no
+> `ryn.json` allows all commands.
+
+**How it works, per platform:**
+- **macOS** — an invisible native drag view sits over the webview and hit-tests the `data-webview-drag`
+  rectangles the script publishes. A mouse-down inside one starts a **native, lag-free** window drag
+  (`performWindowDragWithEvent:`); every other point falls straight through to the DOM, so buttons and
+  inputs in the title bar are clickable. Set `RynOptions.TitleBarDragView = false` to remove the native
+  view and self-manage dragging.
+- **Windows / Linux** — the script starts the drag from the `mousedown` via `window.startDrag`; there is no
+  click-eating overlay, so interactive elements work without extra markup.
 
 ## Which `TitleBarStyle` for a custom title bar?
 
@@ -38,11 +52,16 @@ only when you want the native strip but no title text; use `Overlay` for edge-to
 | `data-webview-resize="<edge>"` | drag-resize from an edge/corner (`top`, `bottom`, `left`, `right`, `top-left`, `top-right`, `bottom-left`, `bottom-right`) |
 | `data-webview-close` | close the window on click |
 | `data-webview-minimize` | minimize on click |
-| `data-webview-maximize` | toggle maximize on click; `data-webview-maximize="double"` toggles only on a double-click |
-| `data-webview-ignore` | exclude an element from all of the above (keep it clickable) |
+| `data-webview-maximize` | toggle maximize on click (double-clicking any `data-webview-drag` region also zooms) |
+| `data-webview-ignore` | exclude an element from dragging (keep it clickable) |
 
-These fire on a left-button `mousedown` and are handled natively, so they work on macOS (WKWebView),
-Windows (WebView2), and Linux (WebKitGTK) alike.
+Window controls fire on `click`; drag and resize fire on left-button `mousedown`. All work on macOS
+(WKWebView), Windows (WebView2), and Linux (WebKitGTK).
+
+**Interactive children inside a drag region.** On macOS the native drag view grabs the whole
+`data-webview-drag` rectangle, so a button *inside* the drag bar must be marked `data-webview-ignore`
+(the window-control attributes above are treated as ignore automatically). Place non-draggable controls
+outside the drag rectangle, or tag them `data-webview-ignore`.
 
 ## Why not `-webkit-app-region: drag`?
 
@@ -50,14 +69,12 @@ Windows (WebView2), and Linux (WebKitGTK) alike.
 on macOS (WKWebView) or Linux (WebKitGTK), and works only incidentally on Windows (WebView2 is Chromium).
 Use `data-webview-drag` instead; it works on every backend.
 
-## Why not `window.startDrag` / `IRynWindow.StartDrag` for title bars?
+## Why not `window.startDrag` / `IRynWindow.StartDrag` directly?
 
-The `window.startDrag` IPC command (and `IRynWindow.StartDrag`) still exists as a programmatic escape
-hatch, but **don't use it to drag a title bar.** It routes through the IPC pipeline (XHR → loopback
-HTTP/scheme → UI-thread marshal), so the native drag begins only *after* the round-trip. On macOS that is
-visibly broken: the native `performWindowDragWithEvent:` reads the *current* event, which by the time the
-command runs is no longer the original mouse-down — so the window lags behind the cursor (drag desync).
-`data-webview-drag` starts the drag synchronously inside the mouse-down, so there is no lag.
+`window.startDrag` still exists as a programmatic escape hatch, but prefer `data-webview-drag`. On macOS
+the attribute path drags natively with no IPC (the drag view starts the OS drag inside the real
+mouse-down), avoiding the cursor desync you get calling `startDrag` from JS after an IPC round-trip. On
+Windows/Linux `data-webview-drag` uses `startDrag` under the hood, which is fine there.
 
 See `samples/VueApp` for a `data-webview-drag` title bar, and [multi-window.md](multi-window.md) for opening
 and managing multiple windows.

--- a/src/Ryn.Core/IRynWindow.cs
+++ b/src/Ryn.Core/IRynWindow.cs
@@ -65,6 +65,14 @@ public interface IRynWindow
     /// <see cref="BackdropMaterial.None"/> where the OS can't render it — query <see cref="GetBackdrop"/> to check.
     /// </summary>
     public void SetBackdrop(BackdropMaterial material);
+    /// <summary>
+    /// Publishes the title bar's draggable and interactive (ignored) rectangles — viewport-top-left CSS
+    /// pixels, each region a flat <c>[x, y, w, h]</c> run. On a macOS Overlay window the native drag view
+    /// then drags only over a drag region and forwards every other click (buttons, inputs) to the page.
+    /// The <c>data-webview-drag</c> script publishes these automatically; apps can also call it directly.
+    /// No effect off macOS or without an overlay drag view.
+    /// </summary>
+    public void SetTitleBarDragRegions(IReadOnlyList<double> drag, IReadOnlyList<double> ignore);
     /// <summary>The backdrop material currently applied — may be <see cref="BackdropMaterial.None"/> if the
     /// requested material degraded on this OS.</summary>
     public BackdropMaterial GetBackdrop();

--- a/src/Ryn.Core/Internal/DeferredRynWindow.cs
+++ b/src/Ryn.Core/Internal/DeferredRynWindow.cs
@@ -64,6 +64,8 @@ internal sealed class DeferredRynWindow(RynWindowAccessor accessor) : IRynWindow
     public void SetClickThrough(bool clickThrough) => Live.SetClickThrough(clickThrough);
     public void SetBackdrop(BackdropMaterial material) => Live.SetBackdrop(material);
     public BackdropMaterial GetBackdrop() => Live.GetBackdrop();
+    public void SetTitleBarDragRegions(IReadOnlyList<double> drag, IReadOnlyList<double> ignore) =>
+        Live.SetTitleBarDragRegions(drag, ignore);
     public void Center() => Live.Center();
     public void StartDrag() => Live.StartDrag();
     public void StartResize(WindowEdge edge) => Live.StartResize(edge);

--- a/src/Ryn.Core/Internal/MacOsTitleBar.cs
+++ b/src/Ryn.Core/Internal/MacOsTitleBar.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
@@ -9,7 +10,19 @@ internal static partial class MacOsTitleBar
     private static nint _dragViewClass;
     private static bool _classRegistered;
 
-    internal static unsafe void Apply(nint nsWindowPtr, bool overlay)
+    // Drag/ignore regions published by the page (the data-webview-* script), keyed by NSWindow* and stored as
+    // viewport-top-left CSS-pixel rects [x,y,w,h,...]. The drag view's hitTest consults them: a point inside an
+    // ignore rect (an interactive control) or outside every drag rect falls through to the webview; a point
+    // inside a drag rect (and not an ignore rect) is a native window drag. Absent → nothing draggable there.
+    private sealed record Regions(double[] Drag, double[] Ignore);
+    private static readonly ConcurrentDictionary<nint, Regions> DragRegions = new();
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NSPoint { public double X, Y; }
+
+    internal static unsafe void Apply(nint nsWindowPtr, bool overlay) => Apply(nsWindowPtr, overlay, dragView: true);
+
+    internal static unsafe void Apply(nint nsWindowPtr, bool overlay, bool dragView)
     {
         if (nsWindowPtr == 0) return;
 
@@ -25,34 +38,47 @@ internal static partial class MacOsTitleBar
             var mask = objc_msgSend_ret_nint(nsWindow, sel_registerName("styleMask"));
             objc_msgSend_nint(nsWindow, sel_registerName("setStyleMask:"), mask | (1 << 15));
 
-            // Native drag view on top of webview in the title bar region
-            AddDragView(nsWindow);
+            // Native drag view over the webview. It only grabs points inside published drag regions (hitTest);
+            // every other point falls through to the DOM. Skipped when the app opts out to self-manage drag.
+            if (dragView) AddDragView(nsWindow);
         }
         // Hidden: no fullSizeContentView — title bar stays as a separate native strip
         // with drag and traffic lights. Content renders below it.
+    }
+
+    /// <summary>
+    /// Publishes the page's draggable and ignored rectangles (viewport-top-left CSS pixels, flat [x,y,w,h,...])
+    /// for a window. The overlay drag view's hitTest uses them to decide drag-vs-forward-to-webview.
+    /// </summary>
+    internal static void SetDragRegions(nint nsWindowPtr, double[] drag, double[] ignore)
+    {
+        if (nsWindowPtr == 0) return;
+        DragRegions[nsWindowPtr] = new Regions(drag ?? [], ignore ?? []);
+    }
+
+    internal static void ClearDragRegions(nint nsWindowPtr)
+    {
+        if (nsWindowPtr != 0) DragRegions.TryRemove(nsWindowPtr, out _);
     }
 
     private static unsafe void AddDragView(void* nsWindow)
     {
         EnsureDragViewClass();
 
-        // Get the window's content view frame to determine width
         var contentView = (void*)objc_msgSend_ret_nint(nsWindow, sel_registerName("contentView"));
         var frame = GetRect(contentView, sel_registerName("frame"));
 
-        // Position: right of traffic lights (x=70), top of window, full remaining width, 28px tall
-        var dragWidth = Math.Max(0, frame.Width - 70);
-        var dragFrame = new NSRect { X = 70, Y = frame.Height - 28, Width = dragWidth, Height = 28 };
+        // Full-content-size overlay: hitTest returns self only inside a published drag region, nil elsewhere,
+        // so the app's drag regions can be any height/position and all other clicks reach the DOM.
+        var dragFrame = new NSRect { X = 0, Y = 0, Width = frame.Width, Height = frame.Height };
 
-        // Create the drag view
         var alloc = objc_msgSend_ret_nint((void*)_dragViewClass, sel_registerName("alloc"));
         var dragView = (void*)objc_msgSend_rect_ret_nint((void*)alloc, sel_registerName("initWithFrame:"), dragFrame);
 
-        // Autoresizing: stick to top, flex width
-        // NSViewWidthSizable = 2, NSViewMinYMargin = 8
-        objc_msgSend_nint(dragView, sel_registerName("setAutoresizingMask:"), 2 | 8);
+        // NSViewWidthSizable(2) | NSViewHeightSizable(16): track the content view on resize.
+        objc_msgSend_nint(dragView, sel_registerName("setAutoresizingMask:"), 2 | 16);
 
-        // Add on top of the webview
+        // Add on top of the webview.
         objc_msgSend_ptr(contentView, sel_registerName("addSubview:"), dragView);
     }
 
@@ -62,6 +88,14 @@ internal static partial class MacOsTitleBar
 
         var superclass = objc_getClass("NSView");
         _dragViewClass = objc_allocateClassPair(superclass, "RynTitleBarDragView", 0);
+
+        // hitTest: — grab only points inside a published drag region; return nil elsewhere so the event
+        // falls through to the webview (a sibling added before this view).
+        class_addMethod(
+            _dragViewClass,
+            sel_registerName("hitTest:"),
+            (nint)(delegate* unmanaged[Cdecl]<nint, nint, NSPoint, nint>)&OnHitTest,
+            "@@:{CGPoint=dd}");
 
         // Override mouseDown: to perform window drag
         class_addMethod(
@@ -80,6 +114,28 @@ internal static partial class MacOsTitleBar
         objc_registerClassPair(_dragViewClass);
         _classRegistered = true;
     }
+
+    // aPoint is in the superview (contentView) coordinate system: bottom-left origin, points. Convert to the
+    // page's top-left CSS pixels (1:1 with points for WKWebView) and test against the published regions.
+    [UnmanagedCallersOnly(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static unsafe nint OnHitTest(nint self, nint sel, NSPoint aPoint)
+        => NativeGuard.Invoke("titlebar.hitTest", (nint)0, () =>
+        {
+            var window = objc_msgSend_ret_nint((void*)self, sel_registerName("window"));
+            if (window == 0 || !DragRegions.TryGetValue(window, out var regions) || regions.Drag.Length < 4)
+                return 0; // nothing draggable → fall through to the webview
+
+            var superview = (void*)objc_msgSend_ret_nint((void*)self, sel_registerName("superview"));
+            if (superview == null) return 0;
+            var bounds = GetRect(superview, sel_registerName("bounds"));
+
+            var cssX = aPoint.X;
+            var cssY = bounds.Height - aPoint.Y; // flip: AppKit bottom-left → CSS top-left
+
+            // Draggable only when the point is inside a drag region and not inside an interactive (ignore)
+            // rect. Otherwise return nil so the click falls through to the webview.
+            return TitleBarRegions.IsDraggable(regions.Drag, regions.Ignore, cssX, cssY) ? self : 0;
+        });
 
     [UnmanagedCallersOnly(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
     private static unsafe void OnMouseDown(nint self, nint sel, nint nsEvent)

--- a/src/Ryn.Core/Internal/TitleBarRegions.cs
+++ b/src/Ryn.Core/Internal/TitleBarRegions.cs
@@ -1,0 +1,31 @@
+namespace Ryn.Core.Internal;
+
+/// <summary>
+/// Pure hit-testing for custom title-bar drag regions, shared by the macOS overlay drag view. Rectangles
+/// are flat <c>[x, y, w, h, …]</c> runs in viewport-top-left CSS pixels, as published by the
+/// <c>data-webview-*</c> script.
+/// </summary>
+internal static class TitleBarRegions
+{
+    /// <summary>
+    /// True when the point should start a window drag: inside a drag rect and not inside any ignore rect
+    /// (an interactive control such as a button or a <c>data-webview-ignore</c> element).
+    /// </summary>
+    public static bool IsDraggable(double[] drag, double[] ignore, double x, double y) =>
+        !Contains(ignore, x, y) && Contains(drag, x, y);
+
+    /// <summary>True when (x, y) falls inside any <c>[x, y, w, h]</c> rect in the flat run.</summary>
+    public static bool Contains(double[] rects, double x, double y)
+    {
+        if (rects is null) return false;
+        for (var i = 0; i + 3 < rects.Length; i += 4)
+        {
+            if (x >= rects[i] && x < rects[i] + rects[i + 2] &&
+                y >= rects[i + 1] && y < rects[i + 1] + rects[i + 3])
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Ryn.Core/RynOptions.cs
+++ b/src/Ryn.Core/RynOptions.cs
@@ -24,6 +24,7 @@ public sealed class RynOptions
     private int _maxHeight;
     private bool _resizable = true;
     private TitleBarStyle _titleBarStyle = TitleBarStyle.Native;
+    private bool _titleBarDragView = true;
     private BackdropMaterial _backdrop = BackdropMaterial.None;
     private bool _transparent;
     private bool _clickThrough;
@@ -72,6 +73,14 @@ public sealed class RynOptions
 
     /// <summary>Controls the window title bar appearance.</summary>
     public TitleBarStyle TitleBarStyle { get => _titleBarStyle; set => Set(ref _titleBarStyle, value); }
+
+    /// <summary>
+    /// Whether an <see cref="TitleBarStyle.Overlay"/> window installs the native macOS drag view. Default
+    /// <c>true</c>: the app marks drag regions with <c>data-webview-drag</c> and the drag view drags only
+    /// there (every other click reaches the DOM). Set <c>false</c> to self-manage dragging via
+    /// <c>window.startDrag</c> on mousedown. No effect off macOS.
+    /// </summary>
+    public bool TitleBarDragView { get => _titleBarDragView; set => Set(ref _titleBarDragView, value); }
 
     /// <summary>Whether the window background is transparent.</summary>
     public bool Transparent { get => _transparent; set => Set(ref _transparent, value); }

--- a/src/Ryn.Core/RynWebView.cs
+++ b/src/Ryn.Core/RynWebView.cs
@@ -570,6 +570,83 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
         }
     }
 
+    internal unsafe void InjectTitleBarScript()
+    {
+        fixed (byte* ptr = TitleBarScript)
+        {
+            Saucer.saucer_webview_inject(
+                (saucer_webview*)_webview,
+                (sbyte*)ptr,
+                saucer_script_time.SAUCER_SCRIPT_TIME_CREATION,
+                1, // no_frames: main frame only
+                0);
+        }
+    }
+
+    // Implements the data-webview-* custom-title-bar contract. Publishes drag/interactive rectangles to the
+    // host (the macOS overlay drag view hit-tests them so only drag regions drag and everything else clicks
+    // through) and wires drag/double-click-zoom/window-control buttons on Windows/Linux where no native drag
+    // view exists. On macOS the native drag view intercepts drag-region mousedowns before the DOM sees them,
+    // so the mousedown->startDrag path here only fires on Windows/Linux — no double drag.
+    private static ReadOnlySpan<byte> TitleBarScript =>
+        """
+        (function(){
+          if (window.top !== window.self) return;
+          var ryn = window.__ryn; if (!ryn) return;
+          function closest(t, sel){ return t && t.closest ? t.closest(sel) : null; }
+          function rectsOf(sel){
+            var out = [], nodes = document.querySelectorAll(sel);
+            for (var i=0;i<nodes.length;i++){
+              var r = nodes[i].getBoundingClientRect();
+              if (r.width>0 && r.height>0) out.push(r.left, r.top, r.width, r.height);
+            }
+            return out;
+          }
+          var scheduled = false;
+          function publish(){
+            scheduled = false;
+            var drag = [], nodes = document.querySelectorAll('[data-webview-drag]');
+            for (var i=0;i<nodes.length;i++){
+              if (closest(nodes[i], '[data-webview-ignore]')) continue;
+              var r = nodes[i].getBoundingClientRect();
+              if (r.width>0 && r.height>0) drag.push(r.left, r.top, r.width, r.height);
+            }
+            var ignore = rectsOf('[data-webview-ignore],[data-webview-minimize],[data-webview-maximize],[data-webview-close],[data-webview-resize]');
+            try { ryn.invoke('window.setTitleBarDragRegions', { drag: drag, ignore: ignore }); } catch(e){}
+          }
+          function schedule(){ if (scheduled) return; scheduled = true; requestAnimationFrame(publish); }
+          function edgeFor(v){
+            switch((v||'').toLowerCase()){
+              case 'top': return 1; case 'bottom': return 2; case 'left': return 4; case 'right': return 8;
+              case 'topleft': return 5; case 'topright': return 9;
+              case 'bottomleft': return 6; case 'bottomright': return 10; default: return 10;
+            }
+          }
+          document.addEventListener('mousedown', function(e){
+            if (e.button !== 0) return;
+            var resize = closest(e.target, '[data-webview-resize]');
+            if (resize){ e.preventDefault(); ryn.invoke('window.startResize', { edge: edgeFor(resize.getAttribute('data-webview-resize')) }); return; }
+            if (closest(e.target, '[data-webview-ignore]')) return;
+            if (closest(e.target, '[data-webview-drag]')){ e.preventDefault(); ryn.invoke('window.startDrag'); }
+          }, true);
+          document.addEventListener('dblclick', function(e){
+            if (closest(e.target, '[data-webview-ignore]')) return;
+            if (closest(e.target, '[data-webview-drag]')) ryn.invoke('window.toggleMaximize');
+          }, true);
+          document.addEventListener('click', function(e){
+            if (closest(e.target, '[data-webview-minimize]')) ryn.invoke('window.minimize');
+            else if (closest(e.target, '[data-webview-maximize]')) ryn.invoke('window.toggleMaximize');
+            else if (closest(e.target, '[data-webview-close]')) ryn.invoke('window.close');
+          }, true);
+          window.addEventListener('resize', schedule);
+          window.addEventListener('load', schedule);
+          document.addEventListener('DOMContentLoaded', schedule);
+          try { new MutationObserver(schedule).observe(document.documentElement,
+            { childList:true, subtree:true, attributes:true, attributeFilter:['style','class','hidden'] }); } catch(e){}
+          schedule();
+        })();
+        """u8;
+
     internal void RaiseFileDrop(FileDropEventArgs args) => FileDrop?.Invoke(this, args);
 
     [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -378,6 +378,9 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         if (_options.DevTools) _rynWebView.InjectConsoleForwardScript();
         _rynWebView.InjectFileDropScript();
         if (_options.TitleBarStyle is TitleBarStyle.Hidden or TitleBarStyle.Overlay) InjectTitleBarInsets();
+        // The data-webview-* drag/control contract is meaningful for any style where the app draws its own
+        // title-bar chrome (Overlay/Hidden/Frameless), not the platform-native bar.
+        if (_options.TitleBarStyle is not TitleBarStyle.Native) _rynWebView.InjectTitleBarScript();
 
         _themeDetector = new SystemThemeDetector();
         _themeDetector.ThemeChanged += t =>
@@ -689,8 +692,21 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         // (INT-11). saucer reports 8 in practice, so this lower bound is defensive only.
         if (size < (nuint)sizeof(nint) || size > 64) return;
         Span<byte> buf = stackalloc byte[(int)size];
-        fixed (byte* ptr = buf) { Saucer.saucer_window_native(_window, 0, ptr, &size); var nsWindow = System.Runtime.InteropServices.MemoryMarshal.Read<nint>(buf); if (nsWindow != 0) MacOsTitleBar.Apply(nsWindow, overlay); }
+        fixed (byte* ptr = buf) { Saucer.saucer_window_native(_window, 0, ptr, &size); var nsWindow = System.Runtime.InteropServices.MemoryMarshal.Read<nint>(buf); if (nsWindow != 0) MacOsTitleBar.Apply(nsWindow, overlay, _options.TitleBarDragView); }
     }
+
+    /// <summary>
+    /// Publishes the page's draggable/ignored title-bar rectangles (viewport-top-left CSS pixels, each a flat
+    /// [x,y,w,h,…] run) so the macOS Overlay drag view drags only over drag regions and forwards every other
+    /// click to the webview. No-op off macOS and when there is no overlay drag view.
+    /// </summary>
+    public void SetTitleBarDragRegions(IReadOnlyList<double> drag, IReadOnlyList<double> ignore) => RunOnUi(() =>
+    {
+        if (_window == null || !OperatingSystem.IsMacOS()) return;
+        var handle = GetNativeWindowHandle();
+        if (handle != 0)
+            MacOsTitleBar.SetDragRegions(handle, [.. drag], [.. ignore]);
+    });
 
     /// <summary>
     /// The underlying saucer window handle (a <c>saucer_window*</c>), or 0 after disposal. For plugin

--- a/src/Ryn.Ipc/WindowCommands.cs
+++ b/src/Ryn.Ipc/WindowCommands.cs
@@ -58,6 +58,15 @@ internal sealed class WindowCommands
     [RynCommand("window.setClickThrough")]
     public void SetClickThrough(bool clickThrough) => _windows.Current.SetClickThrough(clickThrough);
 
+    /// <summary>
+    /// Publishes the title bar's draggable and interactive rectangles (viewport-top-left CSS pixels, each a
+    /// flat [x,y,w,h] run). Normally driven by the injected <c>data-webview-drag</c> script; exposed so an app
+    /// can manage drag regions itself. See <c>IRynWindow.SetTitleBarDragRegions</c>.
+    /// </summary>
+    [RynCommand("window.setTitleBarDragRegions")]
+    public void SetTitleBarDragRegions(double[]? drag, double[]? ignore) =>
+        _windows.Current.SetTitleBarDragRegions(drag ?? [], ignore ?? []);
+
     /// <summary>Sets the window backdrop: "none", "blur", "acrylic", or "mica" (unknown values are ignored).</summary>
     [RynCommand("window.setBackdrop")]
     public void SetBackdrop(string material)

--- a/tests/Ryn.Core.Tests/Internal/TitleBarRegionsTests.cs
+++ b/tests/Ryn.Core.Tests/Internal/TitleBarRegionsTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using Ryn.Core.Internal;
+using Xunit;
+
+namespace Ryn.Core.Tests.Internal;
+
+public sealed class TitleBarRegionsTests
+{
+    // One drag strip [80,0 160x44] and one interactive control (a button) inside it at [100,8 100x28].
+    private static readonly double[] Drag = [80, 0, 160, 44];
+    private static readonly double[] Ignore = [100, 8, 100, 28];
+
+    [Theory]
+    [InlineData(160, 4, true)]    // inside the drag strip, above the button → draggable
+    [InlineData(230, 40, true)]   // inside the drag strip, right of the button → draggable
+    [InlineData(150, 20, false)]  // over the button (ignore rect) → not draggable (click reaches the DOM)
+    [InlineData(340, 20, false)]  // right of the strip entirely → not draggable
+    [InlineData(20, 20, false)]   // over the traffic-light area → not draggable
+    public void IsDraggable_RespectsDragAndIgnoreRegions(double x, double y, bool expected) =>
+        TitleBarRegions.IsDraggable(Drag, Ignore, x, y).Should().Be(expected);
+
+    [Fact]
+    public void IsDraggable_FalseWhenNoDragRegions()
+    {
+        TitleBarRegions.IsDraggable([], [], 100, 10).Should().BeFalse();
+        TitleBarRegions.Contains([], 0, 0).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Contains_HandlesMultipleRects()
+    {
+        double[] rects = [0, 0, 10, 10, 100, 100, 10, 10];
+        TitleBarRegions.Contains(rects, 5, 5).Should().BeTrue();
+        TitleBarRegions.Contains(rects, 105, 105).Should().BeTrue();
+        TitleBarRegions.Contains(rects, 50, 50).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Fixes Cove's Overlay title-bar blocker — two stacked issues, both confirmed against source:
1. `data-webview-drag`/`ignore`/`close`/`minimize`/`maximize`/`resize` were documented but **had no implementation** anywhere.
2. The macOS Overlay drag view blanketed the top strip and swallowed every click (no `hitTest` forwarding, no opt-out).

Now: an injected script publishes drag/interactive rects; the macOS drag view hit-tests them (native lag-free drag only over drag regions, everything else falls through to the DOM); Windows/Linux wire drag/controls via `window.*`. Added `RynOptions.TitleBarDragView` opt-out. Verified on macOS via direct `hitTest:` — a normal button click reaches the DOM, a drag-region click drags.

Needs the `window` capability in `ryn.json` (documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCHwBNFMx7my96k3rSwidW