### PR TITLE
feat: add configurable macOS traffic-light position

### DIFF
--- a/docs/custom-title-bars.md
+++ b/docs/custom-title-bars.md
@@ -63,6 +63,19 @@ Window controls fire on `click`; drag and resize fire on left-button `mousedown`
 (the window-control attributes above are treated as ignore automatically). Place non-draggable controls
 outside the drag rectangle, or tag them `data-webview-ignore`.
 
+## Traffic-light position (macOS)
+
+By default the macOS traffic lights hug the top edge, which looks off in a taller custom title bar. Set
+`RynOptions.TrafficLightPosition` (or call `IRynWindow.SetTrafficLightPosition` / `window.setTrafficLightPosition`
+at runtime) to place the close button's top-left, in points from the window's top-left; the miniaturize and
+zoom buttons follow at their native spacing. Ryn re-applies it on resize.
+
+```csharp
+// Vertically center the (~14pt) lights in a 48pt title bar: (48 - 14) / 2 ≈ 17.
+opts.TitleBarStyle = TitleBarStyle.Overlay;
+opts.TrafficLightPosition = new TrafficLightPosition(X: 20, Y: 17);
+```
+
 ## Why not `-webkit-app-region: drag`?
 
 `-webkit-app-region` is a Chromium/Electron CSS property — it is **not honored by WebKit**. It does nothing

--- a/src/Ryn.Core/IRynWindow.cs
+++ b/src/Ryn.Core/IRynWindow.cs
@@ -73,6 +73,12 @@ public interface IRynWindow
     /// No effect off macOS or without an overlay drag view.
     /// </summary>
     public void SetTitleBarDragRegions(IReadOnlyList<double> drag, IReadOnlyList<double> ignore);
+    /// <summary>
+    /// Positions the macOS traffic-light buttons — the close button's top-left, in points from the window's
+    /// top-left — to vertically center them in a taller custom title bar. Re-applied on resize. No effect
+    /// off macOS.
+    /// </summary>
+    public void SetTrafficLightPosition(TrafficLightPosition position);
     /// <summary>The backdrop material currently applied — may be <see cref="BackdropMaterial.None"/> if the
     /// requested material degraded on this OS.</summary>
     public BackdropMaterial GetBackdrop();

--- a/src/Ryn.Core/Internal/DeferredRynWindow.cs
+++ b/src/Ryn.Core/Internal/DeferredRynWindow.cs
@@ -66,6 +66,7 @@ internal sealed class DeferredRynWindow(RynWindowAccessor accessor) : IRynWindow
     public BackdropMaterial GetBackdrop() => Live.GetBackdrop();
     public void SetTitleBarDragRegions(IReadOnlyList<double> drag, IReadOnlyList<double> ignore) =>
         Live.SetTitleBarDragRegions(drag, ignore);
+    public void SetTrafficLightPosition(TrafficLightPosition position) => Live.SetTrafficLightPosition(position);
     public void Center() => Live.Center();
     public void StartDrag() => Live.StartDrag();
     public void StartResize(WindowEdge edge) => Live.StartResize(edge);

--- a/src/Ryn.Core/Internal/MacOsTitleBar.cs
+++ b/src/Ryn.Core/Internal/MacOsTitleBar.cs
@@ -158,6 +158,92 @@ internal static partial class MacOsTitleBar
             }
         });
 
+    // Requested traffic-light top-left (window-top-left CSS points) per window, so the resize/key observer
+    // can re-apply after AppKit re-lays the buttons out.
+    private static readonly ConcurrentDictionary<nint, NSPoint> TrafficLight = new();
+    private static nint _observerObject;
+    private static bool _observerRegistered;
+
+    /// <summary>
+    /// Moves the traffic-light buttons so the close button's top-left sits at (x, y) measured from the
+    /// window's top-left (points), preserving the buttons' spacing. Re-applied automatically on resize and
+    /// when the window becomes key. Use to vertically center the lights in a taller custom title bar.
+    /// </summary>
+    internal static unsafe void SetTrafficLightPosition(nint nsWindowPtr, double x, double y)
+    {
+        if (nsWindowPtr == 0) return;
+        TrafficLight[nsWindowPtr] = new NSPoint { X = x, Y = y };
+        EnsureObserver(nsWindowPtr);
+        ApplyTrafficLight(nsWindowPtr, x, y);
+    }
+
+    internal static void ClearTrafficLightPosition(nint nsWindowPtr)
+    {
+        if (nsWindowPtr != 0) TrafficLight.TryRemove(nsWindowPtr, out _);
+    }
+
+    private static unsafe void ApplyTrafficLight(nint nsWindowPtr, double x, double y)
+    {
+        var nsWindow = (void*)nsWindowPtr;
+        var close = (void*)objc_msgSend_nint_ret_nint(nsWindow, sel_registerName("standardWindowButton:"), 0);
+        var min = (void*)objc_msgSend_nint_ret_nint(nsWindow, sel_registerName("standardWindowButton:"), 1);
+        var zoom = (void*)objc_msgSend_nint_ret_nint(nsWindow, sel_registerName("standardWindowButton:"), 2);
+        if ((nint)close == 0) return;
+
+        var superview = (void*)objc_msgSend_ret_nint(close, sel_registerName("superview"));
+        if ((nint)superview == 0) return;
+        var superH = GetRect(superview, sel_registerName("bounds")).Height;
+
+        var closeFrame = GetRect(close, sel_registerName("frame"));
+        // Convert the requested top-left y (from the window top) to the superview's bottom-left origin.
+        var newX = x;
+        var newY = superH - y - closeFrame.Height;
+        var dx = newX - closeFrame.X;
+        var dy = newY - closeFrame.Y;
+
+        // Shift all three by the same delta so their native spacing is preserved.
+        foreach (var button in new[] { close, min, zoom })
+        {
+            if ((nint)button == 0) continue;
+            var f = GetRect(button, sel_registerName("frame"));
+            objc_msgSend_setpt(button, sel_registerName("setFrameOrigin:"), new NSPoint { X = f.X + dx, Y = f.Y + dy });
+        }
+    }
+
+    private static unsafe void EnsureObserver(nint nsWindowPtr)
+    {
+        if (!_observerRegistered)
+        {
+            var cls = objc_allocateClassPair(objc_getClass("NSObject"), "RynTrafficLightObserver", 0);
+            class_addMethod(cls, sel_registerName("onNotify:"),
+                (nint)(delegate* unmanaged[Cdecl]<nint, nint, nint, void>)&OnTrafficLightNotify, "v@:@");
+            objc_registerClassPair(cls);
+            _observerObject = objc_msgSend_ret_nint((void*)objc_msgSend_ret_nint((void*)cls, sel_registerName("alloc")), sel_registerName("init"));
+            _observerRegistered = true;
+        }
+
+        // Observe this window's resize and become-key: AppKit re-lays the buttons out on both.
+        var center = (void*)objc_msgSend_ret_nint((void*)objc_getClass("NSNotificationCenter"), sel_registerName("defaultCenter"));
+        foreach (var name in new[] { "NSWindowDidResizeNotification", "NSWindowDidBecomeKeyNotification" })
+        {
+            objc_msgSend_observe((void*)center, sel_registerName("addObserver:selector:name:object:"),
+                (void*)_observerObject, sel_registerName("onNotify:"),
+                (void*)CreateNSString(name), (void*)nsWindowPtr);
+        }
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static unsafe void OnTrafficLightNotify(nint self, nint sel, nint notification)
+        => NativeGuard.Invoke("titlebar.trafficLight", () =>
+        {
+            var window = objc_msgSend_ret_nint((void*)notification, sel_registerName("object"));
+            if (window != 0 && TrafficLight.TryGetValue(window, out var pos))
+                ApplyTrafficLight(window, pos.X, pos.Y);
+        });
+
+    private static unsafe nint CreateNSString(string s) =>
+        objc_msgSend_strarg_ret_nint((void*)objc_getClass("NSString"), sel_registerName("stringWithUTF8String:"), s);
+
     internal static unsafe (double Left, double Top) GetTrafficLightInsets(nint nsWindowPtr)
     {
         if (nsWindowPtr == 0) return (0, 0);
@@ -226,6 +312,22 @@ internal static partial class MacOsTitleBar
     [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     private static unsafe partial nint objc_msgSend_nint_ret_nint(void* receiver, nint selector, nint arg);
+
+    // setFrameOrigin: — NSPoint (2 doubles) by value; arm64 passes it in FP registers via the ordinary trampoline.
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static unsafe partial void objc_msgSend_setpt(void* receiver, nint selector, NSPoint point);
+
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static unsafe partial nint objc_msgSend_strarg_ret_nint(void* receiver, nint selector,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string arg);
+
+    // addObserver:selector:name:object: — (id observer, SEL selector, NSString* name, id object).
+    [LibraryImport("libobjc.dylib", EntryPoint = "objc_msgSend")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static unsafe partial void objc_msgSend_observe(void* receiver, nint selector,
+        void* observer, nint selectorArg, void* name, void* obj);
 
     // NSRect is 32 bytes (4 doubles), so its return ABI differs by architecture:
     //  * arm64  — the Apple AAPCS64 returns the struct in floating-point registers (d0..d3) via the

--- a/src/Ryn.Core/RynOptions.cs
+++ b/src/Ryn.Core/RynOptions.cs
@@ -25,6 +25,7 @@ public sealed class RynOptions
     private bool _resizable = true;
     private TitleBarStyle _titleBarStyle = TitleBarStyle.Native;
     private bool _titleBarDragView = true;
+    private TrafficLightPosition? _trafficLight;
     private BackdropMaterial _backdrop = BackdropMaterial.None;
     private bool _transparent;
     private bool _clickThrough;
@@ -81,6 +82,13 @@ public sealed class RynOptions
     /// <c>window.startDrag</c> on mousedown. No effect off macOS.
     /// </summary>
     public bool TitleBarDragView { get => _titleBarDragView; set => Set(ref _titleBarDragView, value); }
+
+    /// <summary>
+    /// Position of the macOS traffic-light buttons — the close button's top-left, in points from the window's
+    /// top-left. Set it to vertically center the lights in a taller custom title bar (they hug the top edge by
+    /// default). <c>null</c> keeps the platform default. No effect off macOS. Re-applied on resize.
+    /// </summary>
+    public TrafficLightPosition? TrafficLightPosition { get => _trafficLight; set => Set(ref _trafficLight, value); }
 
     /// <summary>Whether the window background is transparent.</summary>
     public bool Transparent { get => _transparent; set => Set(ref _transparent, value); }
@@ -246,6 +254,12 @@ public enum BackdropMaterial
     /// <summary>A subtle desktop-tinted material (Windows 11 mica; macOS approximates with vibrancy).</summary>
     Mica,
 }
+
+/// <summary>
+/// The macOS traffic-light buttons' position: the close button's top-left corner, in points measured from
+/// the window's top-left. The miniaturize and zoom buttons keep their native spacing to the right.
+/// </summary>
+public readonly record struct TrafficLightPosition(double X, double Y);
 
 /// <summary>Controls the appearance and behavior of the window title bar.</summary>
 public enum TitleBarStyle

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -585,6 +585,8 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
                 Saucer.saucer_window_set_decorations(_window, saucer_window_decoration.SAUCER_WINDOW_DECORATION_NONE);
                 break;
         }
+        if (OperatingSystem.IsMacOS() && _options.TrafficLightPosition is { } tlp)
+            ApplyMacOsTrafficLight(tlp.X, tlp.Y);
         if (_options.IconPath is not null && File.Exists(_options.IconPath))
         {
             Span<byte> iconBuf = stackalloc byte[1024];
@@ -707,6 +709,16 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         if (handle != 0)
             MacOsTitleBar.SetDragRegions(handle, [.. drag], [.. ignore]);
     });
+
+    public void SetTrafficLightPosition(TrafficLightPosition position) =>
+        RunOnUi(() => { if (_window != null && OperatingSystem.IsMacOS()) ApplyMacOsTrafficLight(position.X, position.Y); });
+
+    [System.Runtime.Versioning.SupportedOSPlatform("macos")]
+    private void ApplyMacOsTrafficLight(double x, double y)
+    {
+        var handle = GetNativeWindowHandle();
+        if (handle != 0) MacOsTitleBar.SetTrafficLightPosition(handle, x, y);
+    }
 
     /// <summary>
     /// The underlying saucer window handle (a <c>saucer_window*</c>), or 0 after disposal. For plugin

--- a/src/Ryn.Ipc/WindowCommands.cs
+++ b/src/Ryn.Ipc/WindowCommands.cs
@@ -67,6 +67,11 @@ internal sealed class WindowCommands
     public void SetTitleBarDragRegions(double[]? drag, double[]? ignore) =>
         _windows.Current.SetTitleBarDragRegions(drag ?? [], ignore ?? []);
 
+    /// <summary>Positions the macOS traffic-light buttons (close button top-left, points from the window top-left).</summary>
+    [RynCommand("window.setTrafficLightPosition")]
+    public void SetTrafficLightPosition(double x, double y) =>
+        _windows.Current.SetTrafficLightPosition(new TrafficLightPosition(x, y));
+
     /// <summary>Sets the window backdrop: "none", "blur", "acrylic", or "mica" (unknown values are ignored).</summary>
     [RynCommand("window.setBackdrop")]
     public void SetBackdrop(string material)


### PR DESCRIPTION
Implements Cove's traffic-light-position ask (previously deferred). `RynOptions.TrafficLightPosition` / `IRynWindow.SetTrafficLightPosition` / `window.setTrafficLightPosition` place the close button's top-left (points from the window top-left); min/zoom follow at native spacing. Re-applied on resize and become-key.

Verified on macOS by reading the `NSWindowButton` frames back: close lands at the requested point, spacing preserved, survives a resize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCHwBNFMx7my96k3rSwidW