### PR TITLE
fix: release panes inside the close event to avoid use-after-free

### DIFF
--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -46,6 +46,15 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     /// <inheritdoc />
     public event EventHandler? Closed;
 
+    /// <summary>
+    /// Raised after every <see cref="Closing"/> handler has allowed the close, while the native window and
+    /// its child views are still alive. Native teardown that must precede window destruction (e.g. releasing
+    /// child webviews whose saucer event listeners reference the window) belongs here, not on
+    /// <see cref="Closed"/> — by <see cref="Closed"/> the closed-event listener snapshot has already been
+    /// taken, so listeners freed there still get invoked (use-after-free). Not raised for a cancelled close.
+    /// </summary>
+    internal event EventHandler? CloseApproved;
+
     /// <inheritdoc />
     public event EventHandler<WindowResizedEventArgs>? Resized;
 
@@ -769,6 +778,9 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
             var args = new WindowClosingEventArgs();
             self.Closing?.Invoke(self, args);
             if (args.Cancel) { self._rynWebView?.EmitEvent("window.closeCancelled", "{}"); return saucer_policy.SAUCER_POLICY_BLOCK; }
+            // The close is going ahead: run pre-destruction teardown while still inside the native close
+            // event, before saucer snapshots the closed-event listeners (see CloseApproved docs).
+            self.CloseApproved?.Invoke(self, EventArgs.Empty);
             return saucer_policy.SAUCER_POLICY_ALLOW;
         });
     }

--- a/src/Ryn.Plugins.WebViewPane/WebViewPanePlugin.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPanePlugin.cs
@@ -26,8 +26,28 @@ internal sealed class WebViewPanePlugin : IRynPlugin
         // freed-window teardown race live pane webviews.
         var window = _services.GetService<IRynWindow>();
         if (window is not null)
-            window.Closed += (_, _) => service.CloseAll();
+            WirePaneTeardown(window, service.CloseAll);
 
         return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Panes must be released inside the native close event, not after it: every saucer webview keeps a
+    /// non-clearable window-closed listener that captures its native instance, and saucer fires the closed
+    /// event over a snapshot of listeners — a pane freed during <c>Closed</c> has already been copied into
+    /// that snapshot, so its listener runs on freed memory (SIGSEGV on macOS/Windows). Tearing down on
+    /// <see cref="RynWindow.CloseApproved"/> (or <see cref="IRynWindow.Closing"/> for other window
+    /// implementations) lets each pane unhook its listener before the snapshot is taken. The
+    /// <see cref="IRynWindow.Closed"/> subscription stays as a safety net for close paths that skip the
+    /// close event; closeAll is idempotent, so double invocation is harmless.
+    /// </summary>
+    internal static void WirePaneTeardown(IRynWindow window, Action closeAll)
+    {
+        if (window is RynWindow rynWindow)
+            rynWindow.CloseApproved += (_, _) => closeAll();
+        else
+            window.Closing += (_, args) => { if (!args.Cancel) closeAll(); };
+
+        window.Closed += (_, _) => closeAll();
     }
 }

--- a/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
+++ b/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
@@ -245,3 +245,47 @@ public sealed class WebViewPaneDependencyInjectionTests
         public Task InvokeAsync(Action action) => Task.CompletedTask;
     }
 }
+
+/// <summary>
+/// Panes must be torn down inside the native close event (before saucer snapshots the closed-event
+/// listeners), never first on <see cref="IRynWindow.Closed"/> — see WirePaneTeardown. These cover the
+/// interface-fallback wiring; the RynWindow path (CloseApproved) needs a native window.
+/// </summary>
+public sealed class WebViewPanePluginTeardownTests
+{
+    [Fact]
+    public void WirePaneTeardown_ClosesPanesWhenClosingIsNotCancelled()
+    {
+        var window = NSubstitute.Substitute.For<IRynWindow>();
+        var calls = 0;
+        WebViewPanePlugin.WirePaneTeardown(window, () => calls++);
+
+        window.Closing += NSubstitute.Raise.EventWith(window, new WindowClosingEventArgs());
+
+        calls.Should().Be(1, "an allowed close must release panes inside the close event");
+    }
+
+    [Fact]
+    public void WirePaneTeardown_KeepsPanesAliveWhenAnEarlierHandlerCancelledTheClose()
+    {
+        var window = NSubstitute.Substitute.For<IRynWindow>();
+        var calls = 0;
+        WebViewPanePlugin.WirePaneTeardown(window, () => calls++);
+
+        window.Closing += NSubstitute.Raise.EventWith(window, new WindowClosingEventArgs { Cancel = true });
+
+        calls.Should().Be(0, "a cancelled close keeps the window open, so its panes must survive");
+    }
+
+    [Fact]
+    public void WirePaneTeardown_AlsoClosesOnClosedAsASafetyNet()
+    {
+        var window = NSubstitute.Substitute.For<IRynWindow>();
+        var calls = 0;
+        WebViewPanePlugin.WirePaneTeardown(window, () => calls++);
+
+        window.Closed += NSubstitute.Raise.EventWith(window, EventArgs.Empty);
+
+        calls.Should().Be(1);
+    }
+}


### PR DESCRIPTION
Closing an app window after any webview pane existed segfaulted (EXC_BAD_ACCESS in `saucer::webview::impl::set_dev_tools(bool)` from `windowShouldClose:`), reported by a downstream app.

## Root cause

- Every saucer webview registers a non-clearable `window::event::closed` listener capturing its native `this` (`wk.webview.mm:69`; same pattern in the Qt backend).
- saucer/ereignis fires events over a snapshot of listeners, so removing a listener mid-fire does not stop an already-copied callback.
- `WebViewPanePlugin` tore panes down on `Closed`, which maps to `event::closed` — freeing every pane webview in the middle of that snapshot iteration; each freed pane's listener then ran on freed memory.

## Fix

- New internal `RynWindow.CloseApproved`, raised after all `Closing` handlers allow the close, while the native window is still alive. This runs inside saucer's `event::close`, which completes before the `closed` snapshot is taken, so each pane destructor unhooks its listener in time.
- The plugin tears down on `CloseApproved` (covers both interactive and programmatic close — `saucer_window_close` routes through `windowShouldClose:` too), falls back to `Closing` for non-`RynWindow` implementations without destroying panes on a cancelled close, and keeps `Closed` as an idempotent safety net.
- `CloseAll` already runs inline when invoked on the UI thread (`NativeAppHost.InvokeOnUiAsync`), so teardown is synchronous within the close callback — no deadlock, no deferred free.

## Tests

- `WebViewPanePluginTeardownTests`: allowed close tears panes down, cancelled close keeps them alive, `Closed` safety net still fires.
- Full suite green (612 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbchWqeCrCCHQgfbDoA3s3