### PR TITLE
feat: define pane bounds as top-left CSS pixels on every platform

### DIFF
--- a/docs/webview-panes.md
+++ b/docs/webview-panes.md
@@ -24,7 +24,14 @@ changes (resize observers work well). Two consequences to design around:
 
 - Your HTML cannot draw **on top of** a pane — position popovers, context menus, and drag
   overlays outside the pane rect, or hide/shrink the pane while they're open.
-- Panes ignore the page scroll; bounds are window client-area pixels.
+- Panes ignore the page scroll; bounds are **top-left CSS pixels relative to the window content
+  area on every platform** (since 0.23.0). The rect you get from `getBoundingClientRect()` on a
+  placeholder element is exactly what you pass — no per-platform flipping. Bounds are not
+  re-derived on window resize, so re-send them when your layout changes.
+
+> **Upgrading from ≤ 0.22:** on macOS, `x`/`y` used to pass straight into AppKit's bottom-left
+> coordinate space, so apps flipped Y themselves. Ryn now flips internally — delete your own
+> flip when you adopt 0.23.0, or panes will land vertically mirrored again.
 
 ## JS API
 

--- a/src/Ryn.Plugins.WebViewPane/PaneModels.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneModels.cs
@@ -2,7 +2,12 @@ using System.Text.Json.Serialization;
 
 namespace Ryn.Plugins.WebViewPane;
 
-/// <summary>Options for <c>webviewPane.open</c>. Bounds are window client-area pixels.</summary>
+/// <summary>
+/// Options for <c>webviewPane.open</c>. Bounds are top-left CSS pixels relative to the window content
+/// area on every platform (the rect from <c>getBoundingClientRect()</c> places the pane at that visual
+/// position; the macOS bottom-left flip happens internally). Bounds are not re-derived on window resize —
+/// re-send them from JS on layout changes.
+/// </summary>
 public sealed class PaneOpenRequest
 {
     public int X { get; set; }

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
@@ -23,6 +23,7 @@ internal sealed class WebViewPaneCommands
     [RynCommand("webviewPane.close")]
     public Task<bool> CloseAsync(int id) => _service.CloseAsync(id);
 
+    /// <summary>Top-left CSS pixels relative to the window content area on every platform.</summary>
     [RynCommand("webviewPane.setBounds")]
     public void SetBounds(int id, int x, int y, int width, int height) =>
         _service.SetBounds(id, x, y, width, height);

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
@@ -182,7 +182,7 @@ public sealed partial class WebViewPaneService : IDisposable
                     WebViewPaneJsonContext.Default.PaneDownloadFailedEvent)),
         });
 
-        Saucer.saucer_webview_set_bounds(webview, request.X, request.Y, request.Width, request.Height);
+        SetBoundsOnUi((nint)webview, request.X, request.Y, request.Width, request.Height);
 
         if (request.DevTools)
             Saucer.saucer_webview_set_dev_tools(webview, 1);
@@ -246,8 +246,28 @@ public sealed partial class WebViewPaneService : IDisposable
     public void SetBounds(int id, int x, int y, int width, int height) =>
         WithPane(id, (wv, _) => SetBoundsOnUi(wv, x, y, width, height));
 
-    private static unsafe void SetBoundsOnUi(nint webview, int x, int y, int width, int height) =>
-        Saucer.saucer_webview_set_bounds((saucer_webview*)webview, x, y, width, height);
+    // Pane bounds are top-left CSS pixels relative to the window content area on every platform — the rect a
+    // JS caller gets from getBoundingClientRect() places the pane at that visual position. WKWebView frames
+    // live in the contentView's bottom-left, unflipped space, so the Y is converted here; WebView2 is already
+    // top-left. Bounds are not re-derived on window resize: re-apply from JS on layout changes.
+    private unsafe void SetBoundsOnUi(nint webview, int x, int y, int width, int height)
+    {
+        var yNative = y;
+        if (OperatingSystem.IsMacOS())
+        {
+            var windowHandle = _services.GetService<RynWindowAccessor>()?.Window?.SaucerWindowHandle ?? 0;
+            if (windowHandle != 0)
+            {
+                int contentWidth, contentHeight;
+                Saucer.saucer_window_size((saucer_window*)windowHandle, &contentWidth, &contentHeight);
+                yNative = ToMacNativeY(contentHeight, y, height);
+            }
+        }
+        Saucer.saucer_webview_set_bounds((saucer_webview*)webview, x, yNative, width, height);
+    }
+
+    /// <summary>Converts a top-left pane Y to AppKit's bottom-left contentView coordinate.</summary>
+    internal static int ToMacNativeY(int contentHeight, int y, int height) => contentHeight - y - height;
 
     public void Navigate(int id, string url)
     {

--- a/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
+++ b/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
@@ -247,6 +247,21 @@ public sealed class WebViewPaneDependencyInjectionTests
 }
 
 /// <summary>
+/// Pane bounds are top-left CSS pixels relative to the window content area on every platform; on macOS the
+/// Y is converted into AppKit's bottom-left contentView space at apply time.
+/// </summary>
+public sealed class WebViewPaneBoundsTests
+{
+    [Theory]
+    [InlineData(600, 0, 100, 500)]   // pane at the top of a 600pt window → native Y is near the top (500)
+    [InlineData(600, 500, 100, 0)]   // pane at the bottom → native Y 0
+    [InlineData(600, 100, 400, 100)] // mid-window rect
+    [InlineData(400, 0, 400, 0)]     // full-height pane
+    public void ToMacNativeY_FlipsTopLeftIntoBottomLeftSpace(int contentHeight, int y, int height, int expected)
+        => WebViewPaneService.ToMacNativeY(contentHeight, y, height).Should().Be(expected);
+}
+
+/// <summary>
 /// Panes must be torn down inside the native close event (before saucer snapshots the closed-event
 /// listeners), never first on <see cref="IRynWindow.Closed"/> — see WirePaneTeardown. These cover the
 /// interface-fallback wiring; the RynWindow path (CloseApproved) needs a native window.


### PR DESCRIPTION
`webviewPane` bounds (`open` X/Y and `setBounds`) previously passed straight to the native layer: top-left client pixels on Windows (WebView2) but AppKit's **bottom-left, unflipped** contentView space on macOS — the same JS rect placed a pane vertically mirrored between platforms, and every JS caller naturally sends `getBoundingClientRect()` top-left coordinates.

## Change

- The managed layer now defines bounds as **top-left CSS pixels relative to the window content area on every platform** and flips Y internally on macOS (`yNative = contentHeight - y - height`, using `saucer_window_size`, which returns the contentView size there).
- **Breaking on macOS** for apps that compensated by flipping Y themselves (downstream app Cove does) — they must delete their flip when adopting. Called out in `docs/webview-panes.md` with a migration note; shipping as a minor version bump so adopters can gate on it.
- Bounds are not re-derived on window resize; re-send from JS on layout changes (unchanged behavior, now documented).

## Verification

- `WebViewPaneBoundsTests` covers the flip math (top, bottom, mid-window, full-height).
- Live smoke on macOS: panes opened with top-left rects and moved via `setBounds`, clean run.
- The Showcase sample already passed top-left coordinates (it was silently mirrored on macOS before — this fixes it with no sample change).
- Full suite green (616 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbchWqeCrCCHQgfbDoA3s3