### PR TITLE
feat: per-pane background color

### DIFF
--- a/docs/webview-panes.md
+++ b/docs/webview-panes.md
@@ -45,7 +45,8 @@ const id = await window.__ryn.invoke('webviewPane.open', { options: {
   storagePath: '/path/to/session',   // per-pane cookie/storage dir (panes sharing a path share a session)
   devTools: false,
   zoom: 1.0,                         // 0.25–5.0
-  userAgent: 'MyApp/1.0'             // custom UA for this pane (omit for the engine default)
+  userAgent: 'MyApp/1.0',            // custom UA for this pane (omit for the engine default)
+  background: '#1e1e2e'              // painted until first page paint — no white flash in dark UIs
 }});
 
 await window.__ryn.invoke('webviewPane.navigate',    { id, url: 'https://example.com' });
@@ -54,6 +55,7 @@ await window.__ryn.invoke('webviewPane.forward',     { id });
 await window.__ryn.invoke('webviewPane.reload',      { id });
 await window.__ryn.invoke('webviewPane.setBounds',   { id, x: 0, y: 0, width: 800, height: 400 });
 await window.__ryn.invoke('webviewPane.setZoom',     { id, factor: 1.5 });
+await window.__ryn.invoke('webviewPane.setBackground', { id, color: 'rgba(30, 30, 46, 1)' }); // #rgb/#rrggbb/#rrggbbaa/rgb()/rgba()
 await window.__ryn.invoke('webviewPane.setDevTools', { id, enabled: true });
 await window.__ryn.invoke('webviewPane.setUserAgent', { id, userAgent: 'MyApp/1.0' });
 await window.__ryn.invoke('webviewPane.setSuspended', { id, suspended: true }); // hide + throttle

--- a/src/Ryn.Plugins.WebViewPane/PaneColor.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneColor.cs
@@ -1,0 +1,100 @@
+using System.Globalization;
+
+namespace Ryn.Plugins.WebViewPane;
+
+/// <summary>
+/// Parses the CSS-style color strings accepted by <see cref="PaneOpenRequest.Background"/> and
+/// <c>webviewPane.setBackground</c>: <c>#rgb</c>, <c>#rgba</c>, <c>#rrggbb</c>, <c>#rrggbbaa</c>,
+/// <c>rgb(r, g, b)</c> and <c>rgba(r, g, b, a)</c> (alpha 0–1). Anything else is rejected rather than
+/// guessed — a silently-wrong background defeats the whole point of killing the first-paint flash.
+/// </summary>
+internal static class PaneColor
+{
+    public static bool TryParse(string? value, out byte r, out byte g, out byte b, out byte a)
+    {
+        r = g = b = 0;
+        a = 255;
+        if (string.IsNullOrWhiteSpace(value)) return false;
+
+        var s = value.Trim();
+        return s[0] == '#' ? TryParseHex(s.AsSpan(1), ref r, ref g, ref b, ref a)
+                           : TryParseRgbFunction(s, ref r, ref g, ref b, ref a);
+    }
+
+    private static bool TryParseHex(ReadOnlySpan<char> hex, ref byte r, ref byte g, ref byte b, ref byte a)
+    {
+        static bool Nibble(char c, out int v)
+        {
+            v = c switch
+            {
+                >= '0' and <= '9' => c - '0',
+                >= 'a' and <= 'f' => c - 'a' + 10,
+                >= 'A' and <= 'F' => c - 'A' + 10,
+                _ => -1,
+            };
+            return v >= 0;
+        }
+
+        static bool Pair(ReadOnlySpan<char> s, out byte value)
+        {
+            value = 0;
+            if (!Nibble(s[0], out var hi) || !Nibble(s[1], out var lo)) return false;
+            value = (byte)((hi << 4) | lo);
+            return true;
+        }
+
+        switch (hex.Length)
+        {
+            case 3 or 4: // #rgb / #rgba — each nibble doubled, CSS short form
+                Span<char> expanded = stackalloc char[hex.Length * 2];
+                for (var i = 0; i < hex.Length; i++)
+                {
+                    expanded[i * 2] = hex[i];
+                    expanded[i * 2 + 1] = hex[i];
+                }
+                return TryParseHex(expanded, ref r, ref g, ref b, ref a);
+
+            case 6:
+                return Pair(hex, out r) && Pair(hex[2..], out g) && Pair(hex[4..], out b);
+
+            case 8:
+                return Pair(hex, out r) && Pair(hex[2..], out g) && Pair(hex[4..], out b) && Pair(hex[6..], out a);
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryParseRgbFunction(string s, ref byte r, ref byte g, ref byte b, ref byte a)
+    {
+        var hasAlpha = s.StartsWith("rgba", StringComparison.OrdinalIgnoreCase);
+        var open = s.IndexOf('(', StringComparison.Ordinal);
+        if (open < 0 || !s.EndsWith(')') ||
+            !(hasAlpha || s.StartsWith("rgb", StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        var parts = s[(open + 1)..^1].Split(',', StringSplitOptions.TrimEntries);
+        if (parts.Length != (hasAlpha ? 4 : 3)) return false;
+
+        if (!byte.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out r) ||
+            !byte.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out g) ||
+            !byte.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out b))
+        {
+            return false;
+        }
+
+        if (hasAlpha)
+        {
+            if (!double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var alpha) ||
+                alpha is < 0 or > 1)
+            {
+                return false;
+            }
+            a = (byte)Math.Round(alpha * 255);
+        }
+
+        return true;
+    }
+}

--- a/src/Ryn.Plugins.WebViewPane/PaneModels.cs
+++ b/src/Ryn.Plugins.WebViewPane/PaneModels.cs
@@ -37,6 +37,13 @@ public sealed class PaneOpenRequest
 
     /// <summary>Initial zoom factor (1.0 = 100%). Clamped to 0.25–5.0.</summary>
     public double Zoom { get; set; } = 1.0;
+
+    /// <summary>
+    /// Background color painted from creation until the page's first paint (and behind transparent pages):
+    /// <c>#rgb</c>, <c>#rrggbb</c>, <c>#rrggbbaa</c>, <c>rgb()</c> or <c>rgba()</c>. Omit for the engine
+    /// default (white). Set it to your UI's surface color so a pane never flashes a white rectangle.
+    /// </summary>
+    public string? Background { get; set; }
 }
 
 internal sealed record PaneNavigatedEvent(int Id, string Url);

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneCommands.cs
@@ -28,6 +28,10 @@ internal sealed class WebViewPaneCommands
     public void SetBounds(int id, int x, int y, int width, int height) =>
         _service.SetBounds(id, x, y, width, height);
 
+    /// <summary>Background color: #rgb/#rrggbb/#rrggbbaa/rgb()/rgba(). See PaneOpenRequest.Background.</summary>
+    [RynCommand("webviewPane.setBackground")]
+    public void SetBackground(int id, string color) => _service.SetBackground(id, color);
+
     [RynCommand("webviewPane.navigate")]
     public void Navigate(int id, string url) => _service.Navigate(id, url);
 

--- a/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
+++ b/src/Ryn.Plugins.WebViewPane/WebViewPaneService.cs
@@ -109,6 +109,15 @@ public sealed partial class WebViewPaneService : IDisposable
 
     private unsafe int OpenOnUi(PaneOpenRequest request)
     {
+        // Validate before any native allocation so a bad color can't leak a half-created webview.
+        (byte R, byte G, byte B, byte A)? background = null;
+        if (!string.IsNullOrEmpty(request.Background))
+        {
+            if (!PaneColor.TryParse(request.Background, out var r, out var g, out var b, out var a))
+                throw new ArgumentException($"Unrecognized pane background color '{request.Background}'.", nameof(request));
+            background = (r, g, b, a);
+        }
+
         var window = _services.GetService<RynWindowAccessor>()?.Window;
         var windowHandle = window?.SaucerWindowHandle ?? 0;
         if (windowHandle == 0) return -1;
@@ -181,6 +190,11 @@ public sealed partial class WebViewPaneService : IDisposable
                 JsonSerializer.Serialize(new PaneDownloadFailedEvent(state.Id, downloadId, error),
                     WebViewPaneJsonContext.Default.PaneDownloadFailedEvent)),
         });
+
+        // Apply the background before bounds/navigation so the pane never paints the engine-default white.
+        // (Parsed and validated up front, before the webview existed.)
+        if (background is not null)
+            Saucer.saucer_webview_set_background(webview, background.Value.R, background.Value.G, background.Value.B, background.Value.A);
 
         SetBoundsOnUi((nint)webview, request.X, request.Y, request.Width, request.Height);
 
@@ -268,6 +282,17 @@ public sealed partial class WebViewPaneService : IDisposable
 
     /// <summary>Converts a top-left pane Y to AppKit's bottom-left contentView coordinate.</summary>
     internal static int ToMacNativeY(int contentHeight, int y, int height) => contentHeight - y - height;
+
+    /// <summary>Sets the pane's background color (see <see cref="PaneOpenRequest.Background"/> for formats).</summary>
+    public void SetBackground(int id, string color)
+    {
+        if (!PaneColor.TryParse(color, out var r, out var g, out var b, out var a))
+            throw new ArgumentException($"Unrecognized pane background color '{color}'.", nameof(color));
+        WithPane(id, (wv, _) => SetBackgroundOnUi(wv, r, g, b, a));
+    }
+
+    private static unsafe void SetBackgroundOnUi(nint webview, byte r, byte g, byte b, byte a) =>
+        Saucer.saucer_webview_set_background((saucer_webview*)webview, r, g, b, a);
 
     public void Navigate(int id, string url)
     {

--- a/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
+++ b/tests/Ryn.Plugins.Tests/WebViewPaneTests.cs
@@ -226,6 +226,8 @@ public sealed class WebViewPaneDependencyInjectionTests
         service.List().Should().BeEmpty();
         service.GetUrl(99).Should().BeEmpty();
         service.Invoking(s => s.SetBounds(99, 0, 0, 10, 10)).Should().NotThrow();
+        service.Invoking(s => s.SetBackground(99, "#1e1e2e")).Should().NotThrow();
+        service.Invoking(s => s.SetBackground(99, "not-a-color")).Should().Throw<ArgumentException>();
         service.Invoking(s => s.SetZoom(99, 2.0)).Should().NotThrow();
         service.Invoking(s => s.CloseAll()).Should().NotThrow();
         (await service.CloseAsync(99)).Should().BeFalse();
@@ -259,6 +261,40 @@ public sealed class WebViewPaneBoundsTests
     [InlineData(400, 0, 400, 0)]     // full-height pane
     public void ToMacNativeY_FlipsTopLeftIntoBottomLeftSpace(int contentHeight, int y, int height, int expected)
         => WebViewPaneService.ToMacNativeY(contentHeight, y, height).Should().Be(expected);
+}
+
+public sealed class PaneColorTests
+{
+    [Theory]
+    [InlineData("#1e1e2e", 0x1e, 0x1e, 0x2e, 255)]
+    [InlineData("#1e1e2eff", 0x1e, 0x1e, 0x2e, 255)]
+    [InlineData("#1e1e2e80", 0x1e, 0x1e, 0x2e, 0x80)]
+    [InlineData("#fff", 255, 255, 255, 255)]
+    [InlineData("#f00c", 255, 0, 0, 0xcc)]
+    [InlineData("  #ABCDEF  ", 0xab, 0xcd, 0xef, 255)] // whitespace + uppercase
+    [InlineData("rgb(30, 30, 46)", 30, 30, 46, 255)]
+    [InlineData("rgba(30, 30, 46, 0.5)", 30, 30, 46, 128)]
+    [InlineData("rgba(0,0,0,0)", 0, 0, 0, 0)]
+    [InlineData("RGBA(1, 2, 3, 1)", 1, 2, 3, 255)]
+    public void TryParse_AcceptsCssColorForms(string input, int r, int g, int b, int a)
+    {
+        PaneColor.TryParse(input, out var pr, out var pg, out var pb, out var pa).Should().BeTrue();
+        (pr, pg, pb, pa).Should().Be(((byte)r, (byte)g, (byte)b, (byte)a));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("#12345")]           // wrong hex length
+    [InlineData("#gggggg")]          // non-hex digits
+    [InlineData("1e1e2e")]           // missing #
+    [InlineData("rgb(30, 30)")]      // too few components
+    [InlineData("rgb(300, 0, 0)")]   // out of byte range
+    [InlineData("rgba(0, 0, 0, 2)")] // alpha out of 0–1
+    [InlineData("hsl(200, 50%, 50%)")]
+    public void TryParse_RejectsMalformedColors(string? input)
+        => PaneColor.TryParse(input, out _, out _, out _, out _).Should().BeFalse();
 }
 
 /// <summary>


### PR DESCRIPTION
Pane webviews painted solid white from creation until the page's first paint — a white rectangle inside dark UIs. saucer already has `set_background`; it just wasn't exposed through WebViewPane.

- `PaneOpenRequest.Background` (`#rgb` / `#rrggbb` / `#rrggbbaa` / `rgb()` / `rgba()`), applied immediately after webview creation and before bounds/navigation.
- `webviewPane.setBackground(id, color)` for later changes.
- Malformed colors throw (validated before any native allocation, so no half-created webview leaks).
- Live smoke on macOS: pane opened with `background: "#1e1e2e"` plus a later `setBackground`, clean run; parsing covered by `PaneColorTests`. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbchWqeCrCCHQgfbDoA3s3