### PR TITLE
feat: robust picker initial paths and tri-state dialog outcomes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -368,7 +368,7 @@ const hasText = await window.__ryn.invoke('clipboard.hasText', {});
 | Plugin | Package | Registration | Commands |
 |--------|---------|-------------|----------|
 | FileSystem | `Ryn.Plugins.FileSystem` | `AddRynFileSystem(opts => ...)` | `fs.readTextFile`, `fs.writeTextFile`, `fs.readDir`, `fs.stat`, `fs.exists`, `fs.mkdir`, `fs.remove` |
-| Dialog | `Ryn.Plugins.Dialog` | `AddRynDialog()` | `dialog.message`, `dialog.confirm`, `dialog.openFile`, `dialog.openFolder`, `dialog.save` |
+| Dialog | `Ryn.Plugins.Dialog` | `AddRynDialog()` | `dialog.message`, `dialog.confirm`, `dialog.openFile`, `dialog.openFiles`, `dialog.openFolder`, `dialog.save` |
 | Clipboard | `Ryn.Plugins.Clipboard` | `AddRynClipboard()` | `clipboard.readText`, `clipboard.writeText`, `clipboard.hasText`, `clipboard.clear` |
 | Shell | `Ryn.Plugins.Shell` | `AddRynShell(opts => ...)` | `shell.execute`, `shell.open`, `shell.spawn`, `shell.kill`, `shell.pty`, `shell.ptyWrite`, `shell.ptyResize`, `shell.ptyMetrics`, `shell.ptyKill` |
 | Notification | `Ryn.Plugins.Notification` | `AddRynNotification()` | `notification.send`, `notification.isSupported`, `notification.requestPermission` |
@@ -379,6 +379,12 @@ const hasText = await window.__ryn.invoke('clipboard.hasText', {});
 | GlobalShortcut | `Ryn.Plugins.GlobalShortcut` | `AddRynGlobalShortcut()` | `globalShortcut.register`, `globalShortcut.unregister`, `globalShortcut.isRegistered`, `globalShortcut.unregisterAll` |
 | WebViewPane | `Ryn.Plugins.WebViewPane` | `AddRynWebViewPane()` | `webviewPane.open`, `webviewPane.close`, `webviewPane.setBounds`, `webviewPane.navigate`, `webviewPane.back`, `webviewPane.forward`, `webviewPane.reload`, `webviewPane.setZoom`, `webviewPane.setDevTools`, `webviewPane.execute`, `webviewPane.eval`, `webviewPane.url`, `webviewPane.list` |
 | Updater | `Ryn.Plugins.Updater` | `AddRynUpdater(opts => ...)` | `updater.check`, `updater.download`, `updater.apply` |
+
+The file pickers (`dialog.openFile`, `dialog.openFiles`, `dialog.openFolder`, `dialog.save`) resolve to
+the picked path (`openFiles`: a JSON array of paths), `null` when the user cancels, and reject with an
+error when the dialog itself fails. The initial path is best-effort: a leading `~` expands, a file path
+means its directory, and unusable paths (relative or nonexistent) fall back to the platform's default
+location instead of failing.
 
 > **`shell.pty` platform support.** The PTY commands use ConPTY on Windows (Windows 10 1809+) and a native `ryn-pty` shim on macOS and Linux. If that native shim is not present next to the application, `shell.pty` throws a clear `PlatformNotSupportedException` rather than falling back to an unsafe path. The non-PTY `shell.execute`/`shell.open`/`shell.spawn` commands work on all three platforms.
 

--- a/src/Ryn.Plugins.Dialog/PickerCommands.cs
+++ b/src/Ryn.Plugins.Dialog/PickerCommands.cs
@@ -5,15 +5,20 @@ using Ryn.Ipc;
 
 namespace Ryn.Plugins.Dialog;
 
+// Outcome contract (since 0.25.0): a picked path (or JSON array for openFiles), null when the user
+// cancelled, and a thrown exception (surfaced as an IPC error) when the picker itself failed — the three
+// cases used to collapse into "". The initial path is best-effort: leading ~ expands, a file path means
+// its directory, and empty/relative/nonexistent paths fall back to the platform default location instead
+// of being interpolated into a clause that kills the dialog (osascript rejects e.g. `default location "~"`).
 #pragma warning disable CA1812 // Instantiated by generated DI code
 internal sealed class PickerCommands
 #pragma warning restore CA1812
 {
     [RynCommand("dialog.openFile")]
-    public static string OpenFile(string initialPath)
+    public static string? OpenFile(string initialPath)
     {
         if (OperatingSystem.IsMacOS())
-            return RunOsascript($"POSIX path of (choose file default location \"{EscapeAppleScript(initialPath)}\")");
+            return RunOsascript($"POSIX path of (choose file{DefaultLocationClause(initialPath)})");
 
         if (OperatingSystem.IsWindows())
             return RunWindowsDialog("OpenFileDialog", initialPath, "FileName");
@@ -21,14 +26,14 @@ internal sealed class PickerCommands
         if (OperatingSystem.IsLinux())
             return RunLinuxPicker("--file-selection", initialPath);
 
-        return string.Empty;
+        return null;
     }
 
     [RynCommand("dialog.openFolder")]
-    public static string OpenFolder(string initialPath)
+    public static string? OpenFolder(string initialPath)
     {
         if (OperatingSystem.IsMacOS())
-            return RunOsascript($"POSIX path of (choose folder default location \"{EscapeAppleScript(initialPath)}\")");
+            return RunOsascript($"POSIX path of (choose folder{DefaultLocationClause(initialPath)})");
 
         if (OperatingSystem.IsWindows())
             return RunWindowsDialog("FolderBrowserDialog", initialPath, "SelectedPath");
@@ -36,47 +41,48 @@ internal sealed class PickerCommands
         if (OperatingSystem.IsLinux())
             return RunLinuxPicker("--file-selection --directory", initialPath);
 
-        return string.Empty;
+        return null;
     }
 
     [RynCommand("dialog.openFiles")]
-    public static string OpenFiles(string initialPath)
+    public static string? OpenFiles(string initialPath)
     {
         if (OperatingSystem.IsMacOS())
         {
             var script = "set paths to {}\n" +
-                         $"set chosen to (choose file default location \"{EscapeAppleScript(initialPath)}\" with multiple selections allowed)\n" +
+                         $"set chosen to (choose file{DefaultLocationClause(initialPath)} with multiple selections allowed)\n" +
                          "repeat with f in chosen\nset end of paths to POSIX path of f\nend repeat\n" +
                          "set text item delimiters to \"\\n\"\npaths as text";
             var result = RunOsascript(script);
-            return PathsToJsonArray(result);
+            return result is null ? null : PathsToJsonArray(result);
         }
 
         if (OperatingSystem.IsWindows())
         {
+            var normalized = NormalizeInitialPath(initialPath);
             var script = "Add-Type -AssemblyName System.Windows.Forms; " +
                          "$dlg = New-Object System.Windows.Forms.OpenFileDialog; " +
                          "$dlg.Multiselect = $true; " +
-                         (string.IsNullOrEmpty(initialPath) ? "" : $"$dlg.InitialDirectory = '{EscapePowerShell(initialPath)}'; ") +
+                         (normalized is null ? "" : $"$dlg.InitialDirectory = '{EscapePowerShell(normalized)}'; ") +
                          "if ($dlg.ShowDialog() -eq 'OK') { $dlg.FileNames -join \"`n\" }";
             var result = RunPowerShell(script);
-            return PathsToJsonArray(result);
+            return result is null ? null : PathsToJsonArray(result);
         }
 
         if (OperatingSystem.IsLinux())
         {
             var result = RunLinuxPicker("--file-selection --multiple", initialPath);
-            return PathsToJsonArray(result);
+            return result is null ? null : PathsToJsonArray(result);
         }
 
-        return "[]";
+        return null;
     }
 
     [RynCommand("dialog.save")]
-    public static string Save(string initialPath)
+    public static string? Save(string initialPath)
     {
         if (OperatingSystem.IsMacOS())
-            return RunOsascript($"POSIX path of (choose file name default location \"{EscapeAppleScript(initialPath)}\")");
+            return RunOsascript($"POSIX path of (choose file name{DefaultLocationClause(initialPath)})");
 
         if (OperatingSystem.IsWindows())
             return RunWindowsDialog("SaveFileDialog", initialPath, "FileName");
@@ -84,10 +90,47 @@ internal sealed class PickerCommands
         if (OperatingSystem.IsLinux())
             return RunLinuxPicker("--file-selection --save", initialPath);
 
-        return string.Empty;
+        return null;
     }
 
-    private static string RunOsascript(string script)
+    /// <summary>
+    /// Normalizes a caller-supplied initial path into an absolute, existing directory, or null when there
+    /// is no usable one (empty, relative, nonexistent — the dialog then opens at the platform default).
+    /// A leading <c>~</c> expands to the user profile; an existing file resolves to its directory.
+    /// </summary>
+    internal static string? NormalizeInitialPath(string? initialPath)
+    {
+        if (string.IsNullOrWhiteSpace(initialPath)) return null;
+
+        var path = initialPath.Trim();
+        if (path == "~")
+        {
+            path = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        }
+        else if (path.StartsWith("~/", StringComparison.Ordinal) ||
+                 path.StartsWith("~\\", StringComparison.Ordinal))
+        {
+            path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), path[2..]);
+        }
+
+        if (!Path.IsPathRooted(path)) return null;
+        if (File.Exists(path)) return Path.GetDirectoryName(path);
+        return Directory.Exists(path) ? path : null;
+    }
+
+    /// <summary>
+    /// The AppleScript <c>default location</c> clause for a usable initial path, or an empty string to let
+    /// the dialog open at its default — never an interpolated bad path (which errors the whole script).
+    /// </summary>
+    internal static string DefaultLocationClause(string? initialPath)
+    {
+        var normalized = NormalizeInitialPath(initialPath);
+        return normalized is null ? "" : $" default location \"{EscapeAppleScript(normalized)}\"";
+    }
+
+    // AppleScript user-cancel is error -128, which osascript reports as a nonzero exit with the code in
+    // stderr — the only nonzero exit that is not a failure.
+    private static string? RunOsascript(string script)
     {
         var psi = new ProcessStartInfo("osascript")
         {
@@ -99,28 +142,27 @@ internal sealed class PickerCommands
         psi.ArgumentList.Add("-e");
         psi.ArgumentList.Add(script);
 
-        try
-        {
-            using var process = Process.Start(psi);
-            if (process is null) return string.Empty;
-            var output = process.StandardOutput.ReadToEnd().Trim();
-            process.WaitForExit();
-            return process.ExitCode == 0 ? output : string.Empty;
-        }
-        catch (InvalidOperationException) { return string.Empty; }
-        catch (System.ComponentModel.Win32Exception) { return string.Empty; }
+        var (exitCode, output, error) = RunProcess(psi);
+        if (exitCode == 0) return output;
+        if (error.Contains("(-128)", StringComparison.Ordinal)) return null; // user cancelled
+        throw new InvalidOperationException($"The file dialog failed: {error}");
     }
 
-    private static string RunWindowsDialog(string dialogType, string initialPath, string resultProp)
+    private static string? RunWindowsDialog(string dialogType, string initialPath, string resultProp)
     {
+        var normalized = NormalizeInitialPath(initialPath);
+        // FolderBrowserDialog predates InitialDirectory on Windows PowerShell's runtime; SelectedPath is
+        // the pre-selection property it actually has.
+        var initialProp = dialogType == "FolderBrowserDialog" ? "SelectedPath" : "InitialDirectory";
         var script = $"Add-Type -AssemblyName System.Windows.Forms; " +
                      $"$dlg = New-Object System.Windows.Forms.{dialogType}; " +
-                     (string.IsNullOrEmpty(initialPath) ? "" : $"$dlg.InitialDirectory = '{EscapePowerShell(initialPath)}'; ") +
+                     (normalized is null ? "" : $"$dlg.{initialProp} = '{EscapePowerShell(normalized)}'; ") +
                      $"if ($dlg.ShowDialog() -eq 'OK') {{ $dlg.{resultProp} }}";
         return RunPowerShell(script);
     }
 
-    private static string RunPowerShell(string script)
+    // The dialog script prints the picked path only on OK, so exit 0 with empty output is a cancel.
+    private static string? RunPowerShell(string script)
     {
         var psi = new ProcessStartInfo("powershell")
         {
@@ -134,23 +176,18 @@ internal sealed class PickerCommands
         psi.ArgumentList.Add("-Command");
         psi.ArgumentList.Add(script);
 
-        try
-        {
-            using var process = Process.Start(psi);
-            if (process is null) return string.Empty;
-            var output = process.StandardOutput.ReadToEnd().Trim();
-            process.WaitForExit();
-            return process.ExitCode == 0 ? output : string.Empty;
-        }
-        catch (InvalidOperationException) { return string.Empty; }
-        catch (System.ComponentModel.Win32Exception) { return string.Empty; }
+        var (exitCode, output, error) = RunProcess(psi);
+        if (exitCode != 0)
+            throw new InvalidOperationException($"The file dialog failed: {(error.Length > 0 ? error : $"powershell exited with code {exitCode}")}");
+        return output.Length > 0 ? output : null;
     }
 
-    private static string RunLinuxPicker(string flags, string initialPath)
+    private static string? RunLinuxPicker(string flags, string initialPath)
     {
-        var tool = FindLinuxTool();
-        if (tool is null) return string.Empty;
+        var tool = FindLinuxTool()
+            ?? throw new InvalidOperationException("No file dialog tool found. Install zenity or kdialog.");
 
+        var normalized = NormalizeInitialPath(initialPath);
         var psi = new ProcessStartInfo(tool)
         {
             UseShellExecute = false,
@@ -164,8 +201,8 @@ internal sealed class PickerCommands
             foreach (var flag in flags.Split(' ', StringSplitOptions.RemoveEmptyEntries))
                 psi.ArgumentList.Add(flag);
             psi.ArgumentList.Add("--separator=\n");
-            if (!string.IsNullOrEmpty(initialPath))
-                psi.ArgumentList.Add($"--filename={initialPath}/");
+            if (normalized is not null)
+                psi.ArgumentList.Add($"--filename={normalized}/");
         }
         else
         {
@@ -180,7 +217,7 @@ internal sealed class PickerCommands
             else
                 psi.ArgumentList.Add("--getopenfilename");
 
-            psi.ArgumentList.Add(initialPath ?? ".");
+            psi.ArgumentList.Add(normalized ?? ".");
 
             if (isMulti)
             {
@@ -189,16 +226,33 @@ internal sealed class PickerCommands
             }
         }
 
+        // Both zenity and kdialog exit 1 on cancel; anything past 1 is a real failure (zenity uses 5 for
+        // --timeout expiry, -1 for unexpected errors).
+        var (exitCode, output, error) = RunProcess(psi);
+        return exitCode switch
+        {
+            0 => output,
+            1 => null,
+            _ => throw new InvalidOperationException(
+                $"The file dialog failed: {(error.Length > 0 ? error : $"{tool} exited with code {exitCode}")}"),
+        };
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunProcess(ProcessStartInfo psi)
+    {
         try
         {
-            using var process = Process.Start(psi);
-            if (process is null) return string.Empty;
+            using var process = Process.Start(psi)
+                ?? throw new InvalidOperationException($"Failed to start '{psi.FileName}'.");
             var output = process.StandardOutput.ReadToEnd().Trim();
+            var error = process.StandardError.ReadToEnd().Trim();
             process.WaitForExit();
-            return process.ExitCode == 0 ? output : string.Empty;
+            return (process.ExitCode, output, error);
         }
-        catch (InvalidOperationException) { return string.Empty; }
-        catch (System.ComponentModel.Win32Exception) { return string.Empty; }
+        catch (System.ComponentModel.Win32Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to start '{psi.FileName}': {ex.Message}", ex);
+        }
     }
 
     private static string? FindLinuxTool()

--- a/src/Ryn.Plugins.Dialog/Ryn.Plugins.Dialog.csproj
+++ b/src/Ryn.Plugins.Dialog/Ryn.Plugins.Dialog.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Ryn.Plugins.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Ryn.Core\Ryn.Core.csproj" />
     <ProjectReference Include="..\Ryn.Ipc\Ryn.Ipc.csproj" />
     <ProjectReference Include="..\Ryn.Ipc.Generator\Ryn.Ipc.Generator.csproj"

--- a/tests/Ryn.Plugins.Tests/PickerInitialPathTests.cs
+++ b/tests/Ryn.Plugins.Tests/PickerInitialPathTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using Ryn.Plugins.Dialog;
+using Xunit;
+
+namespace Ryn.Plugins.Tests;
+
+/// <summary>
+/// The picker initial path is best-effort: <c>~</c> expands, a file resolves to its directory, and
+/// empty/relative/nonexistent paths yield null so the <c>default location</c> clause is omitted rather
+/// than interpolated (osascript rejects e.g. <c>default location "~"</c> with error -1700, which used to
+/// kill the dialog and surface as an empty string indistinguishable from user-cancel).
+/// </summary>
+public sealed class PickerInitialPathTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("relative/path")]
+    [InlineData("./here")]
+    [InlineData("/definitely/not/an/existing/path/9f8e7d")]
+    public void NormalizeInitialPath_RejectsUnusablePaths(string? input)
+        => PickerCommands.NormalizeInitialPath(input).Should().BeNull();
+
+    [Fact]
+    public void NormalizeInitialPath_ExpandsBareTildeToTheUserProfile()
+        => PickerCommands.NormalizeInitialPath("~").Should()
+            .Be(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+
+    [Fact]
+    public void NormalizeInitialPath_ExpandsTildePrefixedPaths()
+    {
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        // Use a directory that exists in any home: the profile root itself via "~/.".
+        PickerCommands.NormalizeInitialPath("~/.").Should().Be(Path.Combine(home, "."));
+    }
+
+    [Fact]
+    public void NormalizeInitialPath_KeepsExistingAbsoluteDirectories()
+    {
+        var dir = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+        PickerCommands.NormalizeInitialPath(dir).Should().Be(dir);
+    }
+
+    [Fact]
+    public void NormalizeInitialPath_ResolvesAFileToItsDirectory()
+    {
+        var file = Path.Combine(Path.GetTempPath(), $"picker-test-{Guid.NewGuid():N}.txt");
+        File.WriteAllText(file, "x");
+        try
+        {
+            PickerCommands.NormalizeInitialPath(file).Should().Be(Path.GetDirectoryName(file));
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public void DefaultLocationClause_IsOmittedForUnusablePaths()
+    {
+        PickerCommands.DefaultLocationClause("~this-is-not-home").Should().BeEmpty();
+        PickerCommands.DefaultLocationClause("").Should().BeEmpty();
+        PickerCommands.DefaultLocationClause("relative").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DefaultLocationClause_EmitsTheEscapedNormalizedPath()
+    {
+        var dir = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+        PickerCommands.DefaultLocationClause(dir).Should().Be($" default location \"{dir}\"");
+    }
+}


### PR DESCRIPTION
`dialog.openFile/openFiles/openFolder/save` interpolated the caller's initial path into the AppleScript `default location` clause unconditionally, so `~`, relative, or nonexistent paths (and even an empty string) made osascript fail with -1700 — the dialog never appeared and the command returned `""`, indistinguishable from user-cancel.

## Changes

- **Initial path normalization** (all platforms): leading `~` expands to the user profile, an existing file resolves to its directory, and empty/relative/nonexistent paths are dropped so the dialog opens at the platform default.
- **Tri-state outcomes**: picked path (openFiles: JSON array) / `null` on cancel / thrown error (IPC error to JS) on real failure. Cancel detection: osascript stderr `(-128)` (verified live, distinct from the `(-1700)` bad-path error), zenity/kdialog exit 1, PowerShell exit 0 with empty output.
- **Windows folder picker** pre-selects via `SelectedPath` — `FolderBrowserDialog` has no `InitialDirectory` on Windows PowerShell's runtime, so that assignment errored.
- **Linux**: missing zenity/kdialog now throws with an install hint instead of returning empty.

Return contract change (`""` → `null` on cancel) is why this is a minor bump, noted for downstream consumers.

## Tests

- `PickerInitialPathTests` (normalization + clause omission), existing argv/JSON tests unchanged.
- Full suite green (646 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbchWqeCrCCHQgfbDoA3s3