### PR TITLE
feat(window): expose IsMaximized on IRynWindow + window.isMaximized IPC command

### DIFF
--- a/src/Ryn.Core/IRynWindow.cs
+++ b/src/Ryn.Core/IRynWindow.cs
@@ -13,6 +13,10 @@ public interface IRynWindow
     public int Height { get; set; }
     /// <summary>Whether the window can be resized by the user.</summary>
     public bool Resizable { get; set; }
+    /// <summary>Gets a value indicating whether the window is currently maximized.
+    /// The value tracks native maximize/restore events (and the startup
+    /// <c>IsMaximized</c> option), so it is safe to read from any thread.</summary>
+    public bool IsMaximized { get; }
     /// <summary>Occurs before the window closes.</summary>
     public event EventHandler<WindowClosingEventArgs>? Closing;
     /// <summary>Occurs after the window has been confirmed closed.</summary>

--- a/src/Ryn.Core/Internal/DeferredRynWindow.cs
+++ b/src/Ryn.Core/Internal/DeferredRynWindow.cs
@@ -47,6 +47,7 @@ internal sealed class DeferredRynWindow(RynWindowAccessor accessor) : IRynWindow
     public int Width { get => Live.Width; set => Live.Width = value; }
     public int Height { get => Live.Height; set => Live.Height = value; }
     public bool Resizable { get => Live.Resizable; set => Live.Resizable = value; }
+    public bool IsMaximized => Live.IsMaximized;
     public AppTheme Theme => Live.Theme;
 
     public ValueTask ShowAsync(CancellationToken cancellationToken = default) => Live.ShowAsync(cancellationToken);

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -29,6 +29,9 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     private int _cachedWidth;
     private int _cachedHeight;
     private volatile bool _cachedResizable;
+    // Tracks native maximize/restore events plus the startup IsMaximized option, so the
+    // IRynWindow.IsMaximized getter stays lock-free and thread-safe (mirrors _cachedResizable).
+    private volatile bool _isMaximized;
     private int _cachedX;
     private int _cachedY;
     // Last known NON-maximized geometry, tracked separately from the live caches above so a maximized close
@@ -108,6 +111,7 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         _cachedWidth = options.Width;
         _cachedHeight = options.Height;
         _cachedResizable = options.Resizable;
+        _isMaximized = options.IsMaximized == true;
     }
 
     /// <summary>Stable per-application window identifier, assigned by the host when the window is created.</summary>
@@ -325,6 +329,9 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
     /// window/AppKit calls are not thread-safe, so mutating operations are posted to the application loop
     /// (a no-op deferral when already on the UI thread). Safe to call from any thread; inert without a host.
     /// </summary>
+    /// <inheritdoc />
+    public bool IsMaximized => _isMaximized;
+
     private void RunOnUi(Action action)
     {
         if (_disposed)
@@ -1002,6 +1009,7 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         NativeGuard.Invoke("RynWindow.OnWindowMaximize", () =>
         {
             var state = maximized != 0 ? WindowState.Maximized : WindowState.Normal;
+            self._isMaximized = maximized != 0;
             self.StateChanged?.Invoke(self, new WindowStateChangedEventArgs { State = state });
             var stateName = state == WindowState.Maximized ? "maximized" : "normal";
             self._rynWebView?.EmitEvent("window.stateChanged", $"{{\"state\":\"{stateName}\"}}");

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -510,6 +510,10 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
             ApplyInitialPlacement();
         }
 
+        // Sync the cache with the native window now that initial placement and persisted-state restoration have
+        // settled — either path can leave the window maximized without a MAXIMIZE event reaching us. Reading the
+        // native state here gives the subscription below a correct baseline.
+        _isMaximized = Saucer.saucer_window_maximized(_window) != 0;
         SubscribeWindowEvents();
         // The main window is created during AppKit's launch display cycle and loads before it is shown. A
         // secondary window is created after the loop is already running: show it FIRST, then load on the next

--- a/src/Ryn.Ipc/WindowCommands.cs
+++ b/src/Ryn.Ipc/WindowCommands.cs
@@ -25,6 +25,10 @@ internal sealed class WindowCommands
     [RynCommand("window.toggleMaximize")]
     public void ToggleMaximize() => _windows.Current.ToggleMaximize();
 
+    /// <summary>Returns whether the current window is maximized.</summary>
+    [RynCommand("window.isMaximized")]
+    public bool IsMaximized() => _windows.Current.IsMaximized;
+
     /// <summary>Programmatic window drag. For title bars, prefer the <c>data-webview-drag</c> attribute, which
     /// drags natively inside the mousedown with no IPC lag (see docs/custom-title-bars.md).</summary>
     [RynCommand("window.startDrag")]


### PR DESCRIPTION
## Why

There is currently no way for a consumer to **query** the maximized state:

- `saucer_window_maximized` already exists and `RynWindow` uses it internally (`ToggleMaximize`, placement persistence), but only the `ToggleMaximize` action reaches `IRynWindow`.
- Real-world impact (found in [dotnet-deepseek-harness-desktop](https://github.com/ZK-Andy/dotnet-deepseek-harness-desktop)): a hide-to-tray flow wants to restore a maximized window on recall. `ShowAsync` does not preserve maximization, and without a query the app cannot know whether to re-maximize.
- A JS-side workaround is not viable: on WebKitGTK/Wayland `window.outerWidth/Height\* stays frozen at the initial configured size, so page-level heuristics cannot detect maximization.

## What

- `IRynWindow.IsMaximized`: lock-free volatile flag (mirrors the existing `_cachedResizable` pattern)
  - seeded from the `IsMaximized` startup option
  - updated in `OnWindowMaximize` alongside the `StateChanged` raise
- `DeferredRynWindow` forwards to `Live` like every other property
- new `window.isMaximized` IPC command for pages that need it from JS

## Notes

- Purely additive; no behavior change to existing members.
- Built locally: Ryn.Core and Ryn.Ipc compile with zero warnings/errors.
- Tested against the consumer scenario above (tray recall restore); happy to adjust naming/placement to match project conventions.