### PR TITLE
fix: restore inline HTML serving for opts.Html / NavigateToStringAsync

### DIFF
--- a/src/Ryn.Core/RynWebView.cs
+++ b/src/Ryn.Core/RynWebView.cs
@@ -307,6 +307,13 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
 
     internal void SetHtmlContent(string html) => _htmlContent = html;
 
+    internal static InlineHtmlResponse? TryGetInlineHtmlResponse(string? htmlContent, string path) =>
+        htmlContent is not null && path is "/" or "/index.html" or ""
+            ? new InlineHtmlResponse(Encoding.UTF8.GetBytes(htmlContent), "text/html")
+            : null;
+
+    internal sealed record InlineHtmlResponse(byte[] Body, string MimeType);
+
     internal void SetContentDirectory(string path) => _contentDirectory = Path.GetFullPath(path);
 
     internal void SetCrossOriginIsolation(bool enabled) => _crossOriginIsolation = enabled;
@@ -774,23 +781,9 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
             }
         }
 
-        // Serve inline HTML content set via opts.Html / NavigateToStringAsync.
-        if (_htmlContent is not null && (path is "/" or "/index.html" or ""))
+        if (TryGetInlineHtmlResponse(_htmlContent, path) is { } inlineHtml)
         {
-            var htmlBytes = Encoding.UTF8.GetBytes(_htmlContent);
-            fixed (byte* ptr = htmlBytes)
-            {
-                var stash = Saucer.saucer_stash_new_from(ptr, (nuint)htmlBytes.Length);
-                Span<byte> mimeBuf = stackalloc byte[16];
-                var mime = Utf8String.Create("text/html", mimeBuf);
-                var response = Saucer.saucer_scheme_response_new(stash, mime.Pointer);
-                AppendCrossOriginIsolationHeaders(response);
-                Saucer.saucer_scheme_executor_accept(executor, response);
-                // accept() copies the response; we still own (and must free) both native objects.
-                Saucer.saucer_scheme_response_free(response);
-                Saucer.saucer_stash_free(stash);
-                mime.Dispose();
-            }
+            ServeBytes(executor, inlineHtml.Body, inlineHtml.MimeType);
             return;
         }
 

--- a/src/Ryn.Core/RynWebView.cs
+++ b/src/Ryn.Core/RynWebView.cs
@@ -774,6 +774,26 @@ public sealed class RynWebView : IRynWebView, Internal.ILocalServerHost, IDispos
             }
         }
 
+        // Serve inline HTML content set via opts.Html / NavigateToStringAsync.
+        if (_htmlContent is not null && (path is "/" or "/index.html" or ""))
+        {
+            var htmlBytes = Encoding.UTF8.GetBytes(_htmlContent);
+            fixed (byte* ptr = htmlBytes)
+            {
+                var stash = Saucer.saucer_stash_new_from(ptr, (nuint)htmlBytes.Length);
+                Span<byte> mimeBuf = stackalloc byte[16];
+                var mime = Utf8String.Create("text/html", mimeBuf);
+                var response = Saucer.saucer_scheme_response_new(stash, mime.Pointer);
+                AppendCrossOriginIsolationHeaders(response);
+                Saucer.saucer_scheme_executor_accept(executor, response);
+                // accept() copies the response; we still own (and must free) both native objects.
+                Saucer.saucer_scheme_response_free(response);
+                Saucer.saucer_stash_free(stash);
+                mime.Dispose();
+            }
+            return;
+        }
+
         // Resolve and read disk assets off saucer's callback/UI thread. Canonicalization and existence checks
         // follow every symlink before the response is materialized, preserving the containment guard.
         if (_contentDirectory is not null)

--- a/tests/Ryn.Core.Tests/InlineHtmlResponseTests.cs
+++ b/tests/Ryn.Core.Tests/InlineHtmlResponseTests.cs
@@ -1,0 +1,37 @@
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace Ryn.Core.Tests;
+
+public sealed class InlineHtmlResponseTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("/")]
+    [InlineData("/index.html")]
+    public void InlineHtml_IsServedForDocumentPaths(string path)
+    {
+        const string html = "<h1>Ryn inline HTML</h1>";
+
+        var response = RynWebView.TryGetInlineHtmlResponse(html, path);
+
+        response.Should().NotBeNull();
+        response!.MimeType.Should().Be("text/html");
+        Encoding.UTF8.GetString(response.Body).Should().Be(html);
+    }
+
+    [Theory]
+    [InlineData("/app.js")]
+    [InlineData("/index.html/child")]
+    public void InlineHtml_DoesNotShadowAssetPaths(string path)
+    {
+        RynWebView.TryGetInlineHtmlResponse("<h1>Ryn inline HTML</h1>", path).Should().BeNull();
+    }
+
+    [Fact]
+    public void MissingInlineHtml_ReturnsNoResponse()
+    {
+        RynWebView.TryGetInlineHtmlResponse(null, "/index.html").Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Problem

`RynWindowOptions.Html` and `IRynWebView.NavigateToStringAsync` render a blank page on current `main`: `HandleAppSchemeRequest` never serves `_htmlContent`, so `ryn://app/index.html` gets no response. The inline-HTML serving block was dropped during the async file-serving refactor.

## Fix

Restores the `_htmlContent` serving block in `HandleAppSchemeRequest` (serving order: embedded content → inline HTML → content directory), using the same stash/scheme-response path as before.

## Verification

- Reproduced on v0.27.4 (works) vs `main` (blank page); after the fix the page loads and host-initiated JS evaluation succeeds
- `dotnet build Ryn.slnx` — clean