### PR TITLE
feat(window): add idempotent SetMaximized(bool) and window.setMaximized IPC command

### DIFF
--- a/src/Ryn.Core/IRynWindow.cs
+++ b/src/Ryn.Core/IRynWindow.cs
@@ -53,10 +53,8 @@ public interface IRynWindow
     public void Minimize();
     /// <summary>Toggles between maximized and restored window states.</summary>
     public void ToggleMaximize();
-    /// <summary>Maximizes or restores the window. Unlike <see cref="ToggleMaximize"/>, the target state is
-    /// explicit, so repeated calls with the same argument are idempotent and a stale cached
-    /// <see cref="IsMaximized"/> value can never invert the request — safe to call unconditionally
-    /// (e.g. re-maximizing on recall from tray or before the window is shown).</summary>
+    /// <summary>Sets whether the window is maximized. Unlike <see cref="ToggleMaximize"/>, the target state is
+    /// explicit, so callers can safely request the same state more than once.</summary>
     public void SetMaximized(bool maximized);
     /// <summary>Moves the window's top-left corner to the given screen coordinates (in points).</summary>
     public void Move(int x, int y);

--- a/src/Ryn.Core/IRynWindow.cs
+++ b/src/Ryn.Core/IRynWindow.cs
@@ -53,6 +53,11 @@ public interface IRynWindow
     public void Minimize();
     /// <summary>Toggles between maximized and restored window states.</summary>
     public void ToggleMaximize();
+    /// <summary>Maximizes or restores the window. Unlike <see cref="ToggleMaximize"/>, the target state is
+    /// explicit, so repeated calls with the same argument are idempotent and a stale cached
+    /// <see cref="IsMaximized"/> value can never invert the request — safe to call unconditionally
+    /// (e.g. re-maximizing on recall from tray or before the window is shown).</summary>
+    public void SetMaximized(bool maximized);
     /// <summary>Moves the window's top-left corner to the given screen coordinates (in points).</summary>
     public void Move(int x, int y);
     /// <summary>Enters or leaves fullscreen mode.</summary>

--- a/src/Ryn.Core/Internal/DeferredRynWindow.cs
+++ b/src/Ryn.Core/Internal/DeferredRynWindow.cs
@@ -59,6 +59,7 @@ internal sealed class DeferredRynWindow(RynWindowAccessor accessor) : IRynWindow
     public void Close() => Live.Close();
     public void Minimize() => Live.Minimize();
     public void ToggleMaximize() => Live.ToggleMaximize();
+    public void SetMaximized(bool maximized) => Live.SetMaximized(maximized);
     public void Move(int x, int y) => Live.Move(x, y);
     public void SetFullscreen(bool fullscreen) => Live.SetFullscreen(fullscreen);
     public void SetAlwaysOnTop(bool alwaysOnTop) => Live.SetAlwaysOnTop(alwaysOnTop);

--- a/src/Ryn.Core/RynWindow.cs
+++ b/src/Ryn.Core/RynWindow.cs
@@ -232,6 +232,14 @@ public sealed unsafe class RynWindow : IRynWindow, IDisposable
         }
     });
 
+    /// <inheritdoc />
+    public void SetMaximized(bool maximized) => RunOnUi(() =>
+    {
+        // Direct native set: the target state is explicit, so no cached-state read is involved.
+        // The MAXIMIZE/RESTORE event keeps the _isMaximized mirror in sync (same as ToggleMaximize).
+        if (_window != null) Saucer.saucer_window_set_maximized(_window, (byte)(maximized ? 1 : 0));
+    });
+
     public void Move(int x, int y) => RunOnUi(() => { if (_window != null) ApplyPosition(x, y); });
 
     public void SetFullscreen(bool fullscreen) =>

--- a/src/Ryn.Ipc/WindowCommands.cs
+++ b/src/Ryn.Ipc/WindowCommands.cs
@@ -25,8 +25,7 @@ internal sealed class WindowCommands
     [RynCommand("window.toggleMaximize")]
     public void ToggleMaximize() => _windows.Current.ToggleMaximize();
 
-    /// <summary>Maximizes or restores the current window. Idempotent: repeated calls with the same
-    /// argument are no-ops at the native layer, unlike a toggle which inverts on every call.</summary>
+    /// <summary>Sets whether the current window is maximized.</summary>
     [RynCommand("window.setMaximized")]
     public void SetMaximized(bool maximized) => _windows.Current.SetMaximized(maximized);
 

--- a/src/Ryn.Ipc/WindowCommands.cs
+++ b/src/Ryn.Ipc/WindowCommands.cs
@@ -25,6 +25,11 @@ internal sealed class WindowCommands
     [RynCommand("window.toggleMaximize")]
     public void ToggleMaximize() => _windows.Current.ToggleMaximize();
 
+    /// <summary>Maximizes or restores the current window. Idempotent: repeated calls with the same
+    /// argument are no-ops at the native layer, unlike a toggle which inverts on every call.</summary>
+    [RynCommand("window.setMaximized")]
+    public void SetMaximized(bool maximized) => _windows.Current.SetMaximized(maximized);
+
     /// <summary>Returns whether the current window is maximized.</summary>
     [RynCommand("window.isMaximized")]
     public bool IsMaximized() => _windows.Current.IsMaximized;

--- a/tests/Ryn.Ipc.Tests/WindowCommandsTests.cs
+++ b/tests/Ryn.Ipc.Tests/WindowCommandsTests.cs
@@ -17,6 +17,18 @@ namespace Ryn.Ipc.Tests;
 public sealed class WindowCommandsTests
 {
     [Fact]
+    public async Task SetMaximized_ForwardsExplicitStateToCurrentWindow()
+    {
+        var (dispatcher, window) = BuildWindowDispatcher();
+
+        CurrentWindow.Value = window;
+        try { await dispatcher.DispatchAsync("window.setMaximized", JsonArgs("{\"maximized\":true}")); }
+        finally { CurrentWindow.Value = null; }
+
+        window.Received(1).SetMaximized(true);
+    }
+
+    [Fact]
     public async Task SetFullscreen_ForwardsToCurrentWindow()
     {
         var (dispatcher, window) = BuildWindowDispatcher();


### PR DESCRIPTION
## What

Adds an explicit, idempotent `SetMaximized(bool)` to `IRynWindow` (implemented on `RynWindow`, forwarded by `DeferredRynWindow`) plus a matching `window.setMaximized` IPC command — mirroring the shape of #75.

## Why

`ToggleMaximize()` is the only way to set maximize state programmatically today. A toggle inverts whatever state the window happens to be in at call time, which makes it unsafe for "ensure maximized" flows:

- If the cached/native state is stale relative to the caller's intent (e.g. the event mirror lagged behind a hide/show cycle), a toggle **inverts** the request instead of enforcing it.
- Callers that want "maximize, unconditionally" must read `IsMaximized` first and toggle conditionally — a TOCTOU-shaped workaround around their own cache.

The native ABI already exposes `saucer_window_set_maximized(win, byte)`; this PR surfaces it directly so the target state is explicit:

```csharp
// ensure-maximized, safe to repeat
window.SetMaximized(true);
```

Repeated calls with the same argument are no-ops at the native layer, and the existing `MAXIMIZE`/`RESTORE` event subscription keeps the `_isMaximized` mirror in sync exactly as with `ToggleMaximize`.

## Scope

Pure addition: 4 files, +19 lines, no behavior change to any existing API. `window.toggleMaximize` and `IsMaximized` are untouched.

## Validation

- `Ryn.Core` and `Ryn.Ipc` build clean locally (0 warnings).
- Real-motivation data point: a downstream desktop shell uses hide-to-tray + recall; its current recall path needs a "preset maximize before show" plus a post-show correction because a blind toggle can restore an already-maximized window when the mirror lags. An idempotent set collapses that whole class of guard logic.
